### PR TITLE
TH-870 : block_destroy_helper.45

### DIFF
--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/CategoryFilter/CategoryFilterViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/CategoryFilter/CategoryFilterViewModel.swift
@@ -112,13 +112,14 @@ final class CategoryFilterViewModel: BaseViewModel {
     private func fetchData() {
         Task { [weak self] in
             guard let self else { return }
-            
+
             await fetchCategories()
             await fetchCategoryAdvertisement()
             await fetchAdvertisement()
-            
+
             updateDatasource()
         }
+        .store(in: taskBag)
     }
     
     private func fetchCategories() async {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -267,7 +267,7 @@ final class HomeListViewModel: BaseViewModel {
         Task {
             let input = createFetchAroundStoreInput()
             let result = await dependency.storeRepository.fetchAroundStores(input: input)
-            
+
             switch result {
             case .success(let response):
                 state.hasMore = response.cursor.hasMore
@@ -278,6 +278,7 @@ final class HomeListViewModel: BaseViewModel {
                 output.route.send(.showErrorAlert(error))
             }
         }
+        .store(in: taskBag)
     }
     
     private func createFetchAroundStoreInput() -> FetchAroundStoreInput {
@@ -308,12 +309,12 @@ final class HomeListViewModel: BaseViewModel {
             do {
                 let advertisementInput = FetchAdvertisementInput(position: .storeList, size: nil)
                 let advertisements = try await dependency.advertisementRepository.fetchAdvertisements(input: advertisementInput).get()
-                
+
                 state.advertisement = advertisements.advertisements.first
-                
+
                 let input = createFetchAroundStoreInput()
                 let response = try await dependency.storeRepository.fetchAroundStores(input: input).get()
-                
+
                 state.hasMore = response.cursor.hasMore
                 state.nextCursor = response.cursor.nextCursor
                 state.stores.append(contentsOf: response.contents)
@@ -322,6 +323,7 @@ final class HomeListViewModel: BaseViewModel {
                 output.route.send(.showErrorAlert(error))
             }
         }
+        .store(in: taskBag)
     }
     
     private func updateDataSource() {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/SearchAddress/SearchAddressViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/SearchAddress/SearchAddressViewModel.swift
@@ -168,7 +168,7 @@ final class SearchAddressViewModel: BaseViewModel {
     private func searchAddress(keyword: String) {
         Task {
             let result = await mapRepository.searchAddress(keyword: keyword)
-            
+
             switch result {
             case .success(let response):
                 state.address = response.documents
@@ -181,6 +181,7 @@ final class SearchAddressViewModel: BaseViewModel {
                 output.showErrorAlert.send(error)
             }
         }
+        .store(in: taskBag)
     }
     
     private func selectAddress(document: PlaceDocument) {
@@ -208,17 +209,18 @@ final class SearchAddressViewModel: BaseViewModel {
                 addressName: document.addressName,
                 roadAddressName: document.roadAddressName
             )
-            
+
             let _ = await userRepository.saveMyPlace(
                 placeType: .recentSearch,
                 input: input
             )
         }
+        .store(in: taskBag)
     }
     
     private func bindRecentSearchCellViewModel(with data: PlaceResponse) -> RecentSearchAddressCellViewModel {
         let cellViewModel = RecentSearchAddressCellViewModel(data: data)
-        
+
         cellViewModel.output.deleteRecentSearch
             .withUnretained(self)
             .sink { owner, placeId in
@@ -228,12 +230,13 @@ final class SearchAddressViewModel: BaseViewModel {
                         placeId: placeId
                     )
                 }
-                
+                .store(in: owner.taskBag)
+
                 owner.state.recentSearchAddress.removeAll(where: { $0.placeId == placeId })
                 owner.reloadRecentSearchDataSource()
             }
             .store(in: &cellViewModel.cancellables)
-        
+
         return cellViewModel
     }
     


### PR DESCRIPTION
## 원인

Home 모듈의 여러 ViewModel에서 Swift Concurrency의 `Task`를 생성했지만 `taskBag`에 저장하지 않아 발생한 메모리 관리 문제입니다.

**문제가 있었던 코드:**
- `HomeListViewModel`: `fetchAroundStore()`, `fetchDatas()` 메서드
- `CategoryFilterViewModel`: `fetchData()` 메서드
- `SearchAddressViewModel`: `searchAddress()`, `saveAddress()`, `deleteMyPlace` 호출

Task를 taskBag에 저장하지 않으면 ViewModel이 해제될 때 Task가 자동으로 취소되지 않아, Task 클로저 내부에서 캡처한 배열 등의 객체가 적절히 정리되지 않을 수 있습니다. 이로 인해 메모리 해제 과정에서 크래시(`swift_arrayDestroy`, `_xzm_free_abort`)가 발생했습니다.

## 재현 경로

정확한 재현은 어려우나, 다음 상황에서 발생 가능성이 높습니다:

1. 홈 화면에서 가게 목록을 불러오는 중 사용자가 빠르게 화면을 전환하거나 뒤로 가기를 누를 때
2. 필터를 변경하여 데이터를 다시 불러오는 도중 ViewModel이 해제될 때
3. 주소 검색 중 검색어를 빠르게 변경하거나 화면을 닫을 때

비동기 작업(Task)이 완료되지 않은 상태에서 ViewModel이 메모리에서 해제되면서 배열 등의 데이터 구조가 정리되는 과정에서 크래시가 발생합니다.

## 수정 방향

모든 Task에 `.store(in: taskBag)`를 추가하여 Task의 생명주기를 ViewModel과 연결했습니다.

**수정 내용:**
- `HomeListViewModel.swift`: `fetchAroundStore()`, `fetchDatas()` Task를 taskBag에 저장
- `CategoryFilterViewModel.swift`: `fetchData()` Task를 taskBag에 저장
- `SearchAddressViewModel.swift`: `searchAddress()`, `saveAddress()`, `deleteMyPlace` Task를 taskBag에 저장

이를 통해 ViewModel이 해제될 때 실행 중인 모든 Task가 자동으로 취소되고 메모리가 적절히 정리되어 크래시 발생 가능성이 감소합니다.

## 체크리스트

- [x] 크래시 원인 분석 완료
- [x] Home 모듈의 모든 Task에 taskBag 저장 추가
- [x] 코드 리뷰 준비 완료