### PR TITLE
TH-874: UIButton.setSDButton에서 비정상적인 이미지 크기 값으로 인한 메모리 크래시 수정

### DIFF
--- a/Modules/Core/Common/Sources/Extension/UIButton+.swift
+++ b/Modules/Core/Common/Sources/Extension/UIButton+.swift
@@ -7,25 +7,43 @@ import Kingfisher
 public extension UIButton {
     func setSDButton(_ sdButton: SDButton) {
         setTitleColor(UIColor(hex: sdButton.text.fontColor), for: .normal)
-        
+
         if sdButton.text.isHtml {
             let attributedText = ZHTMLParserBuilder.initWithDefault().build().render(sdButton.text.text)
             setAttributedTitle(attributedText, for: .normal)
         } else {
             setTitle(sdButton.text.text, for: .normal)
         }
-        
-        
+
+
         if let image = sdButton.image,
-           let imageUrl = URL(string: image.url) {
+           let imageUrl = URL(string: image.url),
+           isValidImageSize(width: image.style.width, height: image.style.height) {
             let resizeProcessor = ResizingImageProcessor(
                 referenceSize: CGSize(width: image.style.width, height: image.style.height),
                 mode: .aspectFit
             )
-            
-            kf.setImage(with: imageUrl, for: .normal, options: [.processor(resizeProcessor)])
+
+            DispatchQueue.main.async { [weak self] in
+                self?.kf.setImage(with: imageUrl, for: .normal, options: [.processor(resizeProcessor)])
+            }
         }
-        
+
         backgroundColor = UIColor(hex: sdButton.style.backgroundColor)
+    }
+
+    private func isValidImageSize(width: Double, height: Double) -> Bool {
+        let maxSize: Double = 10000
+        let minSize: Double = 1
+
+        guard !width.isNaN && !width.isInfinite && !height.isNaN && !height.isInfinite else {
+            return false
+        }
+
+        guard width >= minSize && width <= maxSize && height >= minSize && height <= maxSize else {
+            return false
+        }
+
+        return true
     }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeStoreCardCell/HomeStoreCardCell.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeStoreCardCell/HomeStoreCardCell.swift
@@ -5,6 +5,7 @@ import DesignSystem
 import Model
 
 import CombineCocoa
+import Kingfisher
 
 final class HomeStoreCardCell: BaseCollectionViewCell {
     enum Layout {
@@ -76,6 +77,7 @@ final class HomeStoreCardCell: BaseCollectionViewCell {
         super.prepareForReuse()
         infoView.prepareForReuse()
         tagStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        actionButton.kf.cancelImageDownloadTask()
     }
     
     override func setup() {


### PR DESCRIPTION
## 원인 분석

### 크래시 정보
- **Issue ID**: `0d7d5db98ccd82ee6310466d3f3eddb4`
- **발생 버전**: 4.29.0 (1)
- **발생 날짜**: 2025-11-19 19:31:36 (KST)
- **크래시 스레드**: `com.apple.uikit.datasource.diffing`

### 크래시 발생 위치
Crashed: com.apple.uikit.datasource.diffing ... 9 Kingfisher 0x6ca44 specialized ResizingImageProcessor.init(referenceSize:mode:) + 567 10 Kingfisher 0x68880 ResizingImageProcessor.init(referenceSize:mode:) + 5596 11 Common 0xfa54 UIButton.setSDButton(_:) + 26 (UIButton+.swift:26) 12 Home 0x35088 block_destroy_helper.9 + 6844


**파일**: `Modules/Core/Common/Sources/Extension/UIButton+.swift:26`

### 근본 원인
`UIButton.setSDButton(_:)` 메서드에서 Kingfisher의 `ResizingImageProcessor`를 생성할 때, 서버로부터 받은 `SDImage.style.width`/`height` 값이 비정상적인 경우 메모리 할당에 실패하여 크래시가 발생했습니다.

**비정상적인 값의 예시:**
- 음수 값 (예: `-1.0`)
- 0 값
- 매우 큰 값 (수백만 픽셀 이상)
- 특수 값 (`NaN`, `Infinity`)

이러한 값으로 `CGSize`를 생성하고 이미지 리사이징을 시도하면 메모리 할당이 실패하여 앱이 크래시됩니다.

---

## 재현 경로

1. 홈 화면에서 `HomeStoreCardCell`이 포함된 UICollectionView 표시
2. Diffable data source가 셀 업데이트 수행
3. 서버 응답 데이터(`HomeCardSectionResponse`)에 비정상적인 이미지 크기를 가진 `SDButton` 포함
4. `HomeStoreCardCell.setupButton()` 호출
5. `actionButton.setSDButton(button)` 실행
6. `UIButton+.swift`의 `setSDButton` 메서드에서 이미지 크기 검증 없이 `ResizingImageProcessor` 생성
7. Kingfisher가 비정상적인 크기로 이미지 처리 시도
8. 메모리 할당 실패로 앱 크래시

---

## 수정 내용

### 1. 이미지 크기 유효성 검증 추가
`UIButton+.swift`에 `isValidImageSize(width:height:)` 메서드를 추가하여 이미지 크기의 유효성을 검증합니다.

**검증 조건:**
- NaN, Infinity 값 체크
- 합리적인 크기 범위 검증: `1 <= size <= 10000`

```swift
private func isValidImageSize(width: Double, height: Double) -> Bool {
    let maxSize: Double = 10000
    let minSize: Double = 1

    guard !width.isNaN && !width.isInfinite && !height.isNaN && !height.isInfinite else {
        return false
    }

    guard width >= minSize && width <= maxSize && height >= minSize && height <= maxSize else {
        return false
    }

    return true
}