### PR TITLE
TH-870 : Home 모듈 추가 ViewModel Task 저장 누락으로 인한 크래시 수정

### DIFF
--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -562,7 +562,7 @@ final class HomeViewModel: BaseViewModel {
                 latitude: location.coordinate.latitude,
                 longitude: location.coordinate.longitude
             )
-            
+
             switch result {
             case .success(let address):
                 state.address = address
@@ -571,6 +571,7 @@ final class HomeViewModel: BaseViewModel {
                 output.route.send(.showErrorAlert(error))
             }
         }
+        .store(in: taskBag)
     }
     
     private func presentCategoryFilter() {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/MarkerPopup/MarkerPopupViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/MarkerPopup/MarkerPopupViewModel.swift
@@ -74,26 +74,28 @@ final class MarkerPopupViewModel: BaseViewModel {
         Task {
             let input = FetchAdvertisementInput(position: .storeMarkerPopup, size: nil)
             let result = await advertisementRepository.fetchAdvertisements(input: input)
-            
+
             switch result {
             case .success(let response):
                 guard let advertisement = response.advertisements.first else { return }
-                
+
                 state.advertisement = advertisement
                 output.advertisement.send(advertisement)
-                
+
             case .failure(let error):
                 output.showErrorAlert.send(error)
             }
         }
+        .store(in: taskBag)
     }
-    
+
     private func sendClickEvent() {
         guard let advertisementId = state.advertisement?.advertisementId else { return }
-        
+
         Task {
             let _ = await eventRepository.sendClickEvent(targetId: advertisementId, type: "ADVERTISEMENT")
         }
+        .store(in: taskBag)
     }
     
     private func sendClickEventLog() {


### PR DESCRIPTION
## 원인

Home 모듈의 `HomeViewModel`과 `MarkerPopupViewModel`에서 Swift Concurrency의 `Task`를 생성했지만 `taskBag`에 저장하지 않아 발생한 메모리 관리 문제입니다.

**문제가 있었던 코드:**
- `HomeViewModel`: `fetchAddress()` 메서드 (line 559)
- `MarkerPopupViewModel`: `fetchMarkerPopup()` 메서드 (line 73), `sendClickEvent()` 메서드 (line 91)

이전 수정(PR #283)에서 일부 ViewModel의 Task를 수정했으나, 위 두 ViewModel의 Task는 누락되어 동일한 크래시가 계속 발생했습니다.

Task를 taskBag에 저장하지 않으면 ViewModel이 해제될 때 Task가 자동으로 취소되지 않아, Task 클로저 내부에서 캡처한 배열 등의 객체가 적절히 정리되지 않을 수 있습니다. 이로 인해 메모리 해제 과정에서 크래시(`block_destroy_helper.45`)가 발생했습니다.

## 재현 경로

1. 앱 실행 후 위치 권한 획득 → 현재 위치 주소 조회 중 빠르게 화면 전환 시
2. 지도에서 마커 탭 → 팝업 표시 및 광고 조회 중 빠르게 팝업 닫기 시
3. 광고 클릭 → 분석 이벤트 전송 중 빠르게 화면 이동 시

비동기 작업(Task)이 완료되지 않은 상태에서 ViewModel이 메모리에서 해제되면서 배열 등의 데이터 구조가 정리되는 과정에서 크래시가 발생합니다.

## 수정 방향

모든 Task에 `.store(in: taskBag)`를 추가하여 Task의 생명주기를 ViewModel과 연결했습니다.

**수정 내용:**
- `HomeViewModel.swift`: `fetchAddress()` Task를 taskBag에 저장
- `MarkerPopupViewModel.swift`: `fetchMarkerPopup()`, `sendClickEvent()` Task를 taskBag에 저장

이를 통해 ViewModel이 해제될 때 실행 중인 모든 Task가 자동으로 취소되고 메모리가 적절히 정리되어 크래시 발생 가능성이 제거됩니다.

## 영향 범위

- 홈 화면 초기 로딩 및 위치 주소 조회
- 마커 팝업 표시 및 광고 로딩
- 광고 클릭 분석 이벤트 전송

**리스크:** 매우 낮음 (단순 메모리 관리 개선, 로직 변경 없음)

## 관련 이슈

- Jira: TH-870
- 이전 수정: PR #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)