### PR TITLE
TH-1057 : 가게 수정 시 반경 거리 내 중복 가게 체크에서 자기 자신 제외

### DIFF
--- a/Modules/Feature/Write/Targets/Interface/Sources/WriteAddressInterface.swift
+++ b/Modules/Feature/Write/Targets/Interface/Sources/WriteAddressInterface.swift
@@ -5,10 +5,12 @@ import CoreLocation
 public struct WriteAddressViewModelConfig {
     public let address: String
     public let location: CLLocation
-    
-    public init(address: String, location: CLLocation) {
+    public let storeId: String?
+
+    public init(address: String, location: CLLocation, storeId: String? = nil) {
         self.address = address
         self.location = location
+        self.storeId = storeId
     }
 }
 

--- a/Modules/Feature/Write/Targets/Write/Sources/Domains/Edit/EditStoreViewModel.swift
+++ b/Modules/Feature/Write/Targets/Write/Sources/Domains/Edit/EditStoreViewModel.swift
@@ -118,10 +118,11 @@ final class EditStoreViewModel: BaseViewModel, EditStoreViewModelInterface  {
         guard let address = state.currentStore.address.fullAddress else { return }
         let config = WriteAddressViewModelConfig(
             address: address,
-            location: state.currentStore.location.toCLLocation
+            location: state.currentStore.location.toCLLocation,
+            storeId: state.currentStore.storeId
         )
         let viewModel = WriteAddressViewModel(config: config)
-        
+
         viewModel.output.finishWriteAddress
             .sink { [weak self] (address: String, location: CLLocation) in
                 self?.didUpdatedAddress(address: address, location: location)

--- a/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteAddress/WriteAddressViewModel.swift
+++ b/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteAddress/WriteAddressViewModel.swift
@@ -38,6 +38,7 @@ extension WriteAddressViewModel {
     
     private struct State {
         var cameraPosition: CLLocation?
+        let editingStoreId: String?
     }
     
     public struct Dependency {
@@ -76,8 +77,8 @@ public final class WriteAddressViewModel: BaseViewModel, WriteAddressViewModelIn
     
     public init(config: WriteAddressViewModelConfig, dependency: Dependency = Dependency()) {
         self.dependency = dependency
-        self.state = State(cameraPosition: config.location)
-        
+        self.state = State(cameraPosition: config.location, editingStoreId: config.storeId)
+
         self.output = Output(
             cameraPosition: .init(config.location),
             address: .init(config.address)
@@ -152,15 +153,22 @@ public final class WriteAddressViewModel: BaseViewModel, WriteAddressViewModelIn
                 mapLongitude: location.coordinate.longitude
             )
             let result = await dependency.storeRepository.fetchAroundStores(input: input)
-            
+
             switch result {
             case .success(let response):
-                if response.contents.isEmpty {
+                let filteredStores: [StoreWithExtraResponse]
+                if let editingStoreId = state.editingStoreId {
+                    filteredStores = response.contents.filter { $0.storeId != editingStoreId }
+                } else {
+                    filteredStores = response.contents
+                }
+
+                if filteredStores.isEmpty {
                     output.finishWriteAddress.send((output.address.value, location))
                 } else {
-                    presentConfirmPopup(stores: response.contents, address: output.address.value)
+                    presentConfirmPopup(stores: filteredStores, address: output.address.value)
                 }
-                
+
             case .failure(let error):
                 output.route.send(.showErrorAlert(error))
             }


### PR DESCRIPTION
## 원인

가게 위치를 수정할 때, 반경 50미터 이내의 중복 가게를 체크하는 로직에서 **현재 수정 중인 가게 자신도 포함**되어 잘못된 중복 경고가 표시되었습니다.

**문제가 있었던 코드:**
- `WriteAddressViewModel.swift`: `checkStoreExistedAround()` 메서드 (line 146-168)
- `EditStoreViewModel.swift`: `pushEditAddress()` 메서드 (line 117-133)
- `WriteAddressViewModelConfig.swift`: storeId 파라미터 없음

**버그 메커니즘:**
1. `EditStoreViewModel.pushEditAddress()`에서 `WriteAddressViewModel` 생성 시 현재 가게의 storeId를 전달하지 않음
2. `WriteAddressViewModel.checkStoreExistedAround()`에서 주변 가게 조회 시 현재 수정 중인 가게를 제외할 방법이 없음
3. API 응답에 현재 수정 중인 가게도 포함되어 "반경 50m 이내 중복 가게 있음" 팝업이 잘못 표시됨

## 재현 경로

1. 앱을 실행하고 로그인
2. 자신이 등록한 가게로 이동
3. 가게 상세 화면에서 "수정" 버튼 탭
4. "가게 위치 수정" 탭
5. **현재 위치를 그대로 유지하고** "주소 설정" 버튼 탭
6. **버그 발생:** "반경 50m 이내 중복 가게가 있습니다" 팝업 표시 (자기 자신이 중복으로 감지됨)

## 수정 방향

**클라이언트 측 필터링 방식**을 사용하여 백엔드 API 변경 없이 현재 수정 중인 가게를 중복 체크에서 제외합니다.

**수정 내용:**
- `WriteAddressInterface.swift`: `WriteAddressViewModelConfig`에 `storeId: String?` 파라미터 추가 (Optional로 하위 호환성 유지)
- `WriteAddressViewModel.swift`: 
  - State에 `editingStoreId` 필드 추가
  - `checkStoreExistedAround()` 메서드에서 `editingStoreId`와 일치하는 가게를 필터링하여 제외
- `EditStoreViewModel.swift`: `pushEditAddress()` 메서드에서 현재 가게의 `storeId` 전달

**효과:**
- 가게 수정 시 자기 자신은 중복 체크에서 제외되어 정상적으로 위치 수정 가능
- 새 가게 등록 시에는 영향 없음 (storeId = nil이므로 기존 로직과 동일)
- 실제 중복 가게만 정확하게 감지

## 영향 범위

### 영향받는 기능
- 가게 위치 수정 flow (EditStoreViewModel → WriteAddressViewModel)

### 영향받지 않는 부분
- 새 가게 등록 flow (storeId가 nil이므로 기존 로직과 동일하게 동작)
- 다른 Write 기능들 (가게 정보 수정, 메뉴 수정 등)

**리스크:** 매우 낮음
- 단순 필터링 로직 추가
- Optional 파라미터로 하위 호환성 유지
- 기존 테스트 케이스 통과 예상

## 관련 이슈

- Jira: TH-1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)