### PR TITLE
TH-1060 : 사장님 가게 리뷰 화면 레이아웃 수정

### DIFF
--- a/Modules/Feature/Store/Targets/Store/Sources/Domains/Review/ReviewList/Subview/ReviewListCell.swift
+++ b/Modules/Feature/Store/Targets/Store/Sources/Domains/Review/ReviewList/Subview/ReviewListCell.swift
@@ -152,8 +152,7 @@ final class ReviewListCell: BaseCollectionViewCell {
         
         photoStackView.snp.makeConstraints {
             $0.top.equalTo(medalBadge.snp.bottom).offset(8)
-            $0.leading.equalToSuperview().inset(16)
-            $0.trailing.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(16)
         }
 
         contentLabel.snp.makeConstraints {


### PR DESCRIPTION
## 원인

`ReviewListCell.swift`의 `photoStackView` 레이아웃 제약 조건이 비대칭적으로 설정되어 있었습니다.

**문제가 있었던 코드:**
- `ReviewListCell.swift`: `bindConstraints()` 메서드 (line 153-157)
  - Line 155: `$0.leading.equalToSuperview().inset(16)` - 좌측에만 16pt 여백
  - Line 156: `$0.trailing.equalToSuperview()` - 우측은 여백 없이 전체 너비 사용

이로 인해 photoStackView가 좌측으로만 들어가고 우측은 화면 끝까지 확장되어 전체적으로 우측으로 밀려 보이는 현상이 발생했습니다.

## 재현 경로

1. 가게 상세 화면으로 이동
2. 리뷰 탭 선택
3. 사진이 포함된 리뷰 항목 확인
4. 사진 영역이 우측으로 밀려 있는 것을 확인

## 수정 방향

`photoStackView`의 제약 조건을 좌우 대칭으로 수정하여 Figma 디자인과 일치시켰습니다.

**수정 내용:**
- `ReviewListCell.swift`: photoStackView의 leading과 trailing을 함께 설정하여 좌우 대칭 16pt 여백 확보
- 불필요한 줄 제거로 코드 간결화

```swift
// Before
photoStackView.snp.makeConstraints {
    $0.top.equalTo(medalBadge.snp.bottom).offset(8)
    $0.leading.equalToSuperview().inset(16)
    $0.trailing.equalToSuperview()
}

// After
photoStackView.snp.makeConstraints {
    $0.top.equalTo(medalBadge.snp.bottom).offset(8)
    $0.leading.trailing.equalToSuperview().inset(16)
}
```

사진 영역이 화면 좌우에 균등한 여백을 가지고 올바르게 정렬됩니다.

## 영향 범위

- 영향받는 화면: 가게 상세 > 리뷰 목록
- 영향받는 컴포넌트: `ReviewListCell` (photoStackView 레이아웃)
- 다른 화면에는 영향 없음

**리스크:** 매우 낮음 (단순 레이아웃 제약 조건 수정으로 다른 로직에 영향 없음)

## 관련 이슈

- Jira: TH-1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)