### PR TITLE
TH-1138 : 홈 화면 필터 서버 드리븐 UI 적용

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "02698a62aeb1fd093df249c26758dd99a211206d84fe7430e0b6dc7b520c0216",
+  "originHash" : "2ac6b32dc5e422e21323b5e82be632b07e08794fa34f24302fc08daea0412e9c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -125,6 +125,15 @@
       "state" : {
         "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
         "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "lookinserver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/QMUI/LookinServer",
+      "state" : {
+        "revision" : "e553d1b689d147817dc54ad5c28fcff71e860101",
+        "version" : "1.2.8"
       }
     },
     {

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -261,7 +261,8 @@ let project = Project(
         .firebaseSDK,
         .netfox,
         .admob,
-        .naverMap
+        .naverMap,
+        .lookinServer
     ],
     settings: .settings(
         base: BuildSetting.Project.base,
@@ -334,6 +335,7 @@ let project = Project(
                 .Package.netfox,
                 .Package.admob,
                 .Package.naverMap,
+                .Package.lookinServer,
                 .target(name: "service-extension"),
                 .target(name: "content-extension"),
             ],

--- a/Modules/Core/Common/Sources/Extension/UILabel+.swift
+++ b/Modules/Core/Common/Sources/Extension/UILabel+.swift
@@ -59,12 +59,12 @@ public extension UILabel {
         textColor = UIColor(hex: sdText.fontColor)
         if sdText.isHtml {
             var parser = ZHTMLParserBuilder.initWithDefault()
-            
+
             if let customFont {
                 let rootStyle = MarkupStyle(font: MarkupStyleFont(customFont))
                 parser = parser.set(rootStyle: rootStyle)
             }
-            
+
             let boldStyle = MarkupStyle(
                 font: MarkupStyleFont(
                     weight: .style(.bold),
@@ -72,7 +72,7 @@ public extension UILabel {
                 )
             )
             parser = parser.set(B_HTMLTagName(), withCustomStyle: boldStyle)
-            
+
             attributedText = parser.build().render(sdText.text)
         } else {
             text = sdText.text

--- a/Modules/Core/Common/Sources/Extension/UIView+.swift
+++ b/Modules/Core/Common/Sources/Extension/UIView+.swift
@@ -2,24 +2,14 @@ import UIKit
 
 import Model
 
-// MARK: SDU
 public extension UIView {
     func setSDSurfaceStyle(_ sdSurfaceStyle: SDSurfaceStyle) {
         backgroundColor = UIColor(hex: sdSurfaceStyle.backgroundColor)
 
-        // 서버 응답: 중첩 border 형태가 표준. flat 형태는 legacy 호출자(예: HomeViewModel.selectedSurface) 호환용.
-        if let border = sdSurfaceStyle.border, let color = UIColor(hex: border.color) {
+        if let border = sdSurfaceStyle.border,
+           let color = UIColor(hex: border.color) {
             layer.borderColor = color.cgColor
             layer.borderWidth = border.width
-        } else if let borderColor = sdSurfaceStyle.borderColor,
-                  let borderWidth = sdSurfaceStyle.borderWidth,
-                  let color = UIColor(hex: borderColor) {
-            layer.borderColor = color.cgColor
-            layer.borderWidth = borderWidth
-        }
-
-        if let cornerRadius = sdSurfaceStyle.cornerRadius {
-            layer.cornerRadius = cornerRadius
         }
     }
 }

--- a/Modules/Core/Common/Sources/Extension/UIView+.swift
+++ b/Modules/Core/Common/Sources/Extension/UIView+.swift
@@ -7,9 +7,13 @@ public extension UIView {
     func setSDSurfaceStyle(_ sdSurfaceStyle: SDSurfaceStyle) {
         backgroundColor = UIColor(hex: sdSurfaceStyle.backgroundColor)
 
-        if let borderColor = sdSurfaceStyle.borderColor,
-           let borderWidth = sdSurfaceStyle.borderWidth,
-           let color = UIColor(hex: borderColor) {
+        // 서버 응답: 중첩 border 형태가 표준. flat 형태는 legacy 호출자(예: HomeViewModel.selectedSurface) 호환용.
+        if let border = sdSurfaceStyle.border, let color = UIColor(hex: border.color) {
+            layer.borderColor = color.cgColor
+            layer.borderWidth = border.width
+        } else if let borderColor = sdSurfaceStyle.borderColor,
+                  let borderWidth = sdSurfaceStyle.borderWidth,
+                  let color = UIColor(hex: borderColor) {
             layer.borderColor = color.cgColor
             layer.borderWidth = borderWidth
         }

--- a/Modules/Core/Log/Project.swift
+++ b/Modules/Core/Log/Project.swift
@@ -8,6 +8,7 @@ let project = Project.makeModule(
     product: .staticLibrary,
     dependencies: [
         .Core.dependencyInjection,
+        .Core.model,
         .Interface.appInterface
     ]
 )

--- a/Modules/Core/Log/Sources/LogEvent.swift
+++ b/Modules/Core/Log/Sources/LogEvent.swift
@@ -1,15 +1,19 @@
 import Foundation
 
+import Model
+
 public protocol LogEventType {
     var screen: ScreenName { set get }
     var name: EventName { set get }
     var extraParameters: [ParameterName: Any]? { set get }
+    /// GA 로 전송될 최종 파라미터. 기본 구현은 extension 에 있으며, 서버 드리븐(SDClickEvent) 등은 자체 구현으로 오버라이드한다.
+    var parameters: [String: Any] { get }
 }
 
 public extension LogEventType {
     var parameters: [String: Any] {
         var result: [String: Any] = [:]
-        
+
         if let extraParameters {
             extraParameters.forEach { key, value in
                 if let objectId = value as? LogObjectId {
@@ -21,7 +25,7 @@ public extension LogEventType {
                 }
             }
         }
-        
+
         result[ParameterName.screen.rawValue] = screen.rawValue
         return result
     }
@@ -36,6 +40,27 @@ public struct ClickEvent: LogEventType {
         screen: ScreenName,
         objectType: LogObjectType,
         objectId: LogObjectId,
+        extraParameters: [ParameterName : Any]? = nil
+    ) {
+        self.screen = screen
+
+        var clickObject: [ParameterName: Any] = [
+            .objectId: objectId,
+            .objectType: objectType
+        ]
+
+        if let extraParameters {
+            clickObject.merge(extraParameters) { _, new in new }
+        }
+
+        self.extraParameters = clickObject
+    }
+
+    /// 서버 응답으로 내려오는 동적 식별자(logKey 등)를 object_id 로 보낼 때 사용.
+    public init(
+        screen: ScreenName,
+        objectType: LogObjectType,
+        objectId: String,
         extraParameters: [ParameterName : Any]? = nil
     ) {
         self.screen = screen
@@ -76,6 +101,49 @@ public struct ImpressionEvent: LogEventType {
         }
 
         self.extraParameters = clickObject
+    }
+}
+
+/// 서버 드리븐 SDClickLog 를 GA 로그로 직렬화하는 ClickEvent 변형.
+/// - SDClickLog.screenName 은 GA `screen` 으로
+/// - SDClickLog.objectType / objectId 는 `extraParameters` 의 object_type / object_id 로
+/// - SDClickLog.extraParameters 는 그대로 GA 파라미터에 병합.
+public struct SDClickEvent: LogEventType {
+    public var screen: ScreenName = .empty
+    public var name: EventName = .click
+    public var extraParameters: [ParameterName: Any]?
+
+    private let clickLog: SDClickLog
+
+    public init(clickLog: SDClickLog, additionalParameters: [ParameterName: Any]? = nil) {
+        self.clickLog = clickLog
+        self.extraParameters = additionalParameters
+    }
+
+    public var parameters: [String: Any] {
+        var result: [String: Any] = [:]
+        result[ParameterName.screen.rawValue] = clickLog.screenName
+        result[ParameterName.objectType.rawValue] = clickLog.objectType
+        result[ParameterName.objectId.rawValue] = clickLog.objectId
+
+        for (key, value) in clickLog.extraParameters {
+            if let raw = value.anyValue {
+                result[key] = raw
+            }
+        }
+
+        if let extraParameters {
+            extraParameters.forEach { key, value in
+                if let objectId = value as? LogObjectId {
+                    result[key.rawValue] = objectId.rawValue
+                } else if let objectType = value as? LogObjectType {
+                    result[key.rawValue] = objectType.rawValue
+                } else {
+                    result[key.rawValue] = value
+                }
+            }
+        }
+        return result
     }
 }
 

--- a/Modules/Core/Log/Sources/LogEvent.swift
+++ b/Modules/Core/Log/Sources/LogEvent.swift
@@ -6,8 +6,6 @@ public protocol LogEventType {
     var screen: ScreenName { set get }
     var name: EventName { set get }
     var extraParameters: [ParameterName: Any]? { set get }
-    /// GA 로 전송될 최종 파라미터. 기본 구현은 extension 에 있으며, 서버 드리븐(SDClickEvent) 등은 자체 구현으로 오버라이드한다.
-    var parameters: [String: Any] { get }
 }
 
 public extension LogEventType {
@@ -56,25 +54,21 @@ public struct ClickEvent: LogEventType {
         self.extraParameters = clickObject
     }
 
-    /// 서버 응답으로 내려오는 동적 식별자(logKey 등)를 object_id 로 보낼 때 사용.
-    public init(
-        screen: ScreenName,
-        objectType: LogObjectType,
-        objectId: String,
-        extraParameters: [ParameterName : Any]? = nil
-    ) {
-        self.screen = screen
+    /// 서버 드리븐 SDClickLog 를 GA 로그로 직렬화. 정적 케이스에 매핑되지 않은 화면명/파라미터 키도 raw 값 그대로 보존된다.
+    public init(clickLog: SDClickLog) {
+        self.screen = ScreenName(rawValue: clickLog.screenName)
 
         var clickObject: [ParameterName: Any] = [
-            .objectId: objectId,
-            .objectType: objectType
+            .objectId: clickLog.objectId,
+            .objectType: clickLog.objectType
         ]
 
-        if let extraParameters {
-            clickObject.merge(extraParameters) { _, new in new }
+        for (key, value) in clickLog.extraParameters {
+            guard let raw = value.anyValue else { continue }
+            clickObject[ParameterName(rawValue: key)] = raw
         }
 
-        self.extraParameters = clickObject
+        self.extraParameters = nil
     }
 }
 
@@ -101,49 +95,6 @@ public struct ImpressionEvent: LogEventType {
         }
 
         self.extraParameters = clickObject
-    }
-}
-
-/// 서버 드리븐 SDClickLog 를 GA 로그로 직렬화하는 ClickEvent 변형.
-/// - SDClickLog.screenName 은 GA `screen` 으로
-/// - SDClickLog.objectType / objectId 는 `extraParameters` 의 object_type / object_id 로
-/// - SDClickLog.extraParameters 는 그대로 GA 파라미터에 병합.
-public struct SDClickEvent: LogEventType {
-    public var screen: ScreenName = .empty
-    public var name: EventName = .click
-    public var extraParameters: [ParameterName: Any]?
-
-    private let clickLog: SDClickLog
-
-    public init(clickLog: SDClickLog, additionalParameters: [ParameterName: Any]? = nil) {
-        self.clickLog = clickLog
-        self.extraParameters = additionalParameters
-    }
-
-    public var parameters: [String: Any] {
-        var result: [String: Any] = [:]
-        result[ParameterName.screen.rawValue] = clickLog.screenName
-        result[ParameterName.objectType.rawValue] = clickLog.objectType
-        result[ParameterName.objectId.rawValue] = clickLog.objectId
-
-        for (key, value) in clickLog.extraParameters {
-            if let raw = value.anyValue {
-                result[key] = raw
-            }
-        }
-
-        if let extraParameters {
-            extraParameters.forEach { key, value in
-                if let objectId = value as? LogObjectId {
-                    result[key.rawValue] = objectId.rawValue
-                } else if let objectType = value as? LogObjectType {
-                    result[key.rawValue] = objectType.rawValue
-                } else {
-                    result[key.rawValue] = value
-                }
-            }
-        }
-        return result
     }
 }
 

--- a/Modules/Core/Log/Sources/ParameterName.swift
+++ b/Modules/Core/Log/Sources/ParameterName.swift
@@ -1,30 +1,38 @@
 import Foundation
 
-public enum ParameterName: String {
-    case screen
-    case objectId = "object_id"
-    case objectType = "object_type"
-    case type
-    case nickname
-    case address
-    case categoryName = "category_name"
-    case storeId = "store_id"
-    case value
-    case advertisementId = "advertisement_id"
-    case categoryId = "category_id"
-    case count
-    case reviewId = "review_id"
-    case rating
-    case pollId = "poll_id"
-    case optionId = "option_id"
-    case title
-    case pollFirstOption = "poll_first_option"
-    case pollSecondOption = "poll_second_option"
-    case buildingName = "building_name"
-    case medalId = "medal_id"
-    case storeType = "store_type"
-    case experimentType = "experiment_type"
-    case experimentKey = "experiment_key"
-    case experimentVariant = "experiment_variant"
-    case referer
+public struct ParameterName: RawRepresentable, Hashable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+public extension ParameterName {
+    static let screen = ParameterName(rawValue: "screen")
+    static let objectId = ParameterName(rawValue: "object_id")
+    static let objectType = ParameterName(rawValue: "object_type")
+    static let type = ParameterName(rawValue: "type")
+    static let nickname = ParameterName(rawValue: "nickname")
+    static let address = ParameterName(rawValue: "address")
+    static let categoryName = ParameterName(rawValue: "category_name")
+    static let storeId = ParameterName(rawValue: "store_id")
+    static let value = ParameterName(rawValue: "value")
+    static let advertisementId = ParameterName(rawValue: "advertisement_id")
+    static let categoryId = ParameterName(rawValue: "category_id")
+    static let count = ParameterName(rawValue: "count")
+    static let reviewId = ParameterName(rawValue: "review_id")
+    static let rating = ParameterName(rawValue: "rating")
+    static let pollId = ParameterName(rawValue: "poll_id")
+    static let optionId = ParameterName(rawValue: "option_id")
+    static let title = ParameterName(rawValue: "title")
+    static let pollFirstOption = ParameterName(rawValue: "poll_first_option")
+    static let pollSecondOption = ParameterName(rawValue: "poll_second_option")
+    static let buildingName = ParameterName(rawValue: "building_name")
+    static let medalId = ParameterName(rawValue: "medal_id")
+    static let storeType = ParameterName(rawValue: "store_type")
+    static let experimentType = ParameterName(rawValue: "experiment_type")
+    static let experimentKey = ParameterName(rawValue: "experiment_key")
+    static let experimentVariant = ParameterName(rawValue: "experiment_variant")
+    static let referer = ParameterName(rawValue: "referer")
 }

--- a/Modules/Core/Log/Sources/ScreenName.swift
+++ b/Modules/Core/Log/Sources/ScreenName.swift
@@ -1,77 +1,85 @@
 import Foundation
 
-public enum ScreenName: String {
-    case empty
-    
-    case splash
-    
-    case markerPopup = "marker_popup"
-    
+public struct ScreenName: RawRepresentable, Hashable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+public extension ScreenName {
+    static let empty = ScreenName(rawValue: "empty")
+
+    static let splash = ScreenName(rawValue: "splash")
+
+    static let markerPopup = ScreenName(rawValue: "marker_popup")
+
     // Membership
-    case signIn = "sign_in"
-    case signUp = "sign_up"
-    case accountInfo = "account_info"
-    
+    static let signIn = ScreenName(rawValue: "sign_in")
+    static let signUp = ScreenName(rawValue: "sign_up")
+    static let accountInfo = ScreenName(rawValue: "account_info")
+
     // Home
-    case home
-    case homeList = "home_list"
-    case categoryFilter = "category_filter"
-    case mainAdBanner = "main_ad_banner"
-    case searchAddress = "search_address"
-    
+    static let home = ScreenName(rawValue: "home")
+    static let homeList = ScreenName(rawValue: "home_list")
+    static let categoryFilter = ScreenName(rawValue: "category_filter")
+    static let mainAdBanner = ScreenName(rawValue: "main_ad_banner")
+    static let searchAddress = ScreenName(rawValue: "search_address")
+
     /// Write
-    case writeAddress = "write_address"
-    case writeAddressPopup = "write_address_popup"
-    case writeAddressDetail = "write_address_detail"
-    case writeAddressBossBottomSheet = "write_address_boss_bottom_sheet"
-    case writeDetailComplete = "write_detail_complete"
-    case writeDetailAdditionalInfo = "write_detail_additional_info"
-    case writeDetailCategory = "write_detail_category"
-    case writeDetailCategoryBottomSheet = "write_detail_category_botom_sheet"
-    case writeDetailInfo = "write_detail_info"
-    case writeDetailMenu = "write_detail_menu"
-    case categorySelection = "category_selection"
-    case editStore = "edit_store"
-    case editStoreInfo = "edit_store_info"
-    
+    static let writeAddress = ScreenName(rawValue: "write_address")
+    static let writeAddressPopup = ScreenName(rawValue: "write_address_popup")
+    static let writeAddressDetail = ScreenName(rawValue: "write_address_detail")
+    static let writeAddressBossBottomSheet = ScreenName(rawValue: "write_address_boss_bottom_sheet")
+    static let writeDetailComplete = ScreenName(rawValue: "write_detail_complete")
+    static let writeDetailAdditionalInfo = ScreenName(rawValue: "write_detail_additional_info")
+    static let writeDetailCategory = ScreenName(rawValue: "write_detail_category")
+    static let writeDetailCategoryBottomSheet = ScreenName(rawValue: "write_detail_category_botom_sheet")
+    static let writeDetailInfo = ScreenName(rawValue: "write_detail_info")
+    static let writeDetailMenu = ScreenName(rawValue: "write_detail_menu")
+    static let categorySelection = ScreenName(rawValue: "category_selection")
+    static let editStore = ScreenName(rawValue: "edit_store")
+    static let editStoreInfo = ScreenName(rawValue: "edit_store_info")
+
     /// Store
-    case storeDetail = "store_detail"
-    case uploadPhoto = "upload_photo"
-    case reviewList = "review_list"
-    case reportStore = "report_store"
-    case reviewBottomSheet = "review_bottom_sheet"
-    case visitStore = "visit_store"
-    case bossStoreDetail = "boss_store_detail"
-    case bossStoreReview = "boss_store_review"
-    case bossStoreReviewWrite = "boss_store_review_write"
-    case bossStorePhoto = "boss_store_photo"
-    case storeDetailBridge = "store_detail_bridge"
-    case storeContributors = "store_contributors"
-    
+    static let storeDetail = ScreenName(rawValue: "store_detail")
+    static let uploadPhoto = ScreenName(rawValue: "upload_photo")
+    static let reviewList = ScreenName(rawValue: "review_list")
+    static let reportStore = ScreenName(rawValue: "report_store")
+    static let reviewBottomSheet = ScreenName(rawValue: "review_bottom_sheet")
+    static let visitStore = ScreenName(rawValue: "visit_store")
+    static let bossStoreDetail = ScreenName(rawValue: "boss_store_detail")
+    static let bossStoreReview = ScreenName(rawValue: "boss_store_review")
+    static let bossStoreReviewWrite = ScreenName(rawValue: "boss_store_review_write")
+    static let bossStorePhoto = ScreenName(rawValue: "boss_store_photo")
+    static let storeDetailBridge = ScreenName(rawValue: "store_detail_bridge")
+    static let storeContributors = ScreenName(rawValue: "store_contributors")
+
     /// Community
-    case community = "community"
-    case pollDetail = "poll_detail"
-    case pollList = "poll_list"
-    case reportPoll = "report_poll"
-    case reportReview = "report_review"
-    case createPoll = "careate_poll"
-    
+    static let community = ScreenName(rawValue: "community")
+    static let pollDetail = ScreenName(rawValue: "poll_detail")
+    static let pollList = ScreenName(rawValue: "poll_list")
+    static let reportPoll = ScreenName(rawValue: "report_poll")
+    static let reportReview = ScreenName(rawValue: "report_review")
+    static let createPoll = ScreenName(rawValue: "careate_poll")
+
     // MyPage
-    case myPage = "my_page"
-    case registeredStore = "registered_store"
-    case visitedList = "visited_list"
-    case clickReview = "click_review"
-    case myReview = "my_review"
-    case myMedal = "my_medal"
-    case myBookmarkList = "my_bookmark_list"
-    case editBookmarkList = "edit_bookmark_list"
-    case bookmarkListViewer = "bookmark_list_viewer"
-    case setting
-    case editNickname = "edit_nickname"
-    case qna
-    case faq
-    case teamInfo = "team_info"
-    
+    static let myPage = ScreenName(rawValue: "my_page")
+    static let registeredStore = ScreenName(rawValue: "registered_store")
+    static let visitedList = ScreenName(rawValue: "visited_list")
+    static let clickReview = ScreenName(rawValue: "click_review")
+    static let myReview = ScreenName(rawValue: "my_review")
+    static let myMedal = ScreenName(rawValue: "my_medal")
+    static let myBookmarkList = ScreenName(rawValue: "my_bookmark_list")
+    static let editBookmarkList = ScreenName(rawValue: "edit_bookmark_list")
+    static let bookmarkListViewer = ScreenName(rawValue: "bookmark_list_viewer")
+    static let setting = ScreenName(rawValue: "setting")
+    static let editNickname = ScreenName(rawValue: "edit_nickname")
+    static let qna = ScreenName(rawValue: "qna")
+    static let faq = ScreenName(rawValue: "faq")
+    static let teamInfo = ScreenName(rawValue: "team_info")
+
     // Feed
-    case feedList = "feed_list"
+    static let feedList = ScreenName(rawValue: "feed_list")
 }

--- a/Modules/Core/Model/Sources/Domain/Input/FetchAroundStoreInput.swift
+++ b/Modules/Core/Model/Sources/Domain/Input/FetchAroundStoreInput.swift
@@ -4,35 +4,55 @@ public struct FetchAroundStoreInput: Encodable {
     public let distanceM: Double
     public let categoryIds: [String]?
     public let targetStores: [StoreType]?
-    public let sortType: StoreSortType
-    public let filterCertifiedStores: Bool?
-    public let filterConditions: [ActivitiesStatus]?
     public let size: Int
     public let cursor: String?
     public let mapLatitude: Double
     public let mapLongitude: Double
-    
+    public let dynamicParams: [String: String]
+
     public init(
         distanceM: Double,
         categoryIds: [String]? = nil,
         targetStores: [StoreType] = [.userStore, .bossStore],
-        sortType: StoreSortType = .distanceAsc,
-        filterCertifiedStores: Bool? = false,
-        filterConditions: [ActivitiesStatus]? = nil,
         size: Int = 10,
         cursor: String? = nil,
         mapLatitude: Double,
-        mapLongitude: Double
+        mapLongitude: Double,
+        dynamicParams: [String: String] = [:]
     ) {
         self.distanceM = distanceM
         self.categoryIds = categoryIds
         self.targetStores = targetStores
-        self.sortType = sortType
-        self.filterCertifiedStores = filterCertifiedStores
-        self.filterConditions = filterConditions
         self.size = size
         self.cursor = cursor
         self.mapLatitude = mapLatitude
         self.mapLongitude = mapLongitude
+        self.dynamicParams = dynamicParams
+    }
+
+    private struct DynamicCodingKey: CodingKey {
+        let stringValue: String
+        var intValue: Int? { nil }
+
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) { nil }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        try container.encode(distanceM, forKey: DynamicCodingKey(stringValue: "distanceM"))
+        try container.encodeIfPresent(categoryIds, forKey: DynamicCodingKey(stringValue: "categoryIds"))
+        try container.encodeIfPresent(targetStores, forKey: DynamicCodingKey(stringValue: "targetStores"))
+        try container.encode(size, forKey: DynamicCodingKey(stringValue: "size"))
+        try container.encodeIfPresent(cursor, forKey: DynamicCodingKey(stringValue: "cursor"))
+        try container.encode(mapLatitude, forKey: DynamicCodingKey(stringValue: "mapLatitude"))
+        try container.encode(mapLongitude, forKey: DynamicCodingKey(stringValue: "mapLongitude"))
+
+        for (key, value) in dynamicParams {
+            try container.encode(value, forKey: DynamicCodingKey(stringValue: key))
+        }
     }
 }

--- a/Modules/Core/Model/Sources/Domain/Input/FetchHomeCardInput.swift
+++ b/Modules/Core/Model/Sources/Domain/Input/FetchHomeCardInput.swift
@@ -4,38 +4,55 @@ public struct FetchHomeCardInput: Encodable {
     public let distanceM: Double
     public let categoryIds: [String]?
     public let targetStores: [StoreType]?
-    public let sortType: StoreSortType
-    public let filterCertifiedStores: Bool?
-    public let filterOpenStatuses: [FilterOpenStatuses]?
-    public let filterConditions: [ActivitiesStatus]?
     public let size: Int
     public let cursor: String?
     public let mapLatitude: Double
     public let mapLongitude: Double
+    public let dynamicParams: [String: String]
 
     public init(
         distanceM: Double,
         categoryIds: [String]? = nil,
         targetStores: [StoreType] = [.userStore, .bossStore],
-        sortType: StoreSortType = .distanceAsc,
-        filterCertifiedStores: Bool? = false,
-        filterOpenStatuses: [FilterOpenStatuses]? = nil,
-        filterConditions: [ActivitiesStatus]? = nil,
         size: Int = 10,
         cursor: String? = nil,
         mapLatitude: Double,
-        mapLongitude: Double
+        mapLongitude: Double,
+        dynamicParams: [String: String] = [:]
     ) {
         self.distanceM = distanceM
         self.categoryIds = categoryIds
         self.targetStores = targetStores
-        self.sortType = sortType
-        self.filterCertifiedStores = filterCertifiedStores
-        self.filterOpenStatuses = filterOpenStatuses
-        self.filterConditions = filterConditions
         self.size = size
         self.cursor = cursor
         self.mapLatitude = mapLatitude
         self.mapLongitude = mapLongitude
+        self.dynamicParams = dynamicParams
+    }
+
+    private struct DynamicCodingKey: CodingKey {
+        let stringValue: String
+        var intValue: Int? { nil }
+
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) { nil }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        try container.encode(distanceM, forKey: DynamicCodingKey(stringValue: "distanceM"))
+        try container.encodeIfPresent(categoryIds, forKey: DynamicCodingKey(stringValue: "categoryIds"))
+        try container.encodeIfPresent(targetStores, forKey: DynamicCodingKey(stringValue: "targetStores"))
+        try container.encode(size, forKey: DynamicCodingKey(stringValue: "size"))
+        try container.encodeIfPresent(cursor, forKey: DynamicCodingKey(stringValue: "cursor"))
+        try container.encode(mapLatitude, forKey: DynamicCodingKey(stringValue: "mapLatitude"))
+        try container.encode(mapLongitude, forKey: DynamicCodingKey(stringValue: "mapLongitude"))
+
+        for (key, value) in dynamicParams {
+            try container.encode(value, forKey: DynamicCodingKey(stringValue: key))
+        }
     }
 }

--- a/Modules/Core/Model/Sources/Domain/Input/FetchHomeCardInput.swift
+++ b/Modules/Core/Model/Sources/Domain/Input/FetchHomeCardInput.swift
@@ -6,18 +6,20 @@ public struct FetchHomeCardInput: Encodable {
     public let targetStores: [StoreType]?
     public let sortType: StoreSortType
     public let filterCertifiedStores: Bool?
+    public let filterOpenStatuses: [FilterOpenStatuses]?
     public let filterConditions: [ActivitiesStatus]?
     public let size: Int
     public let cursor: String?
     public let mapLatitude: Double
     public let mapLongitude: Double
-    
+
     public init(
         distanceM: Double,
         categoryIds: [String]? = nil,
         targetStores: [StoreType] = [.userStore, .bossStore],
         sortType: StoreSortType = .distanceAsc,
         filterCertifiedStores: Bool? = false,
+        filterOpenStatuses: [FilterOpenStatuses]? = nil,
         filterConditions: [ActivitiesStatus]? = nil,
         size: Int = 10,
         cursor: String? = nil,
@@ -29,6 +31,7 @@ public struct FetchHomeCardInput: Encodable {
         self.targetStores = targetStores
         self.sortType = sortType
         self.filterCertifiedStores = filterCertifiedStores
+        self.filterOpenStatuses = filterOpenStatuses
         self.filterConditions = filterConditions
         self.size = size
         self.cursor = cursor

--- a/Modules/Core/Model/Sources/Domain/Response/FilterOpenStatuses.swift
+++ b/Modules/Core/Model/Sources/Domain/Response/FilterOpenStatuses.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public enum FilterOpenStatuses: String, Codable {
+    case open = "OPEN"
+    case closed = "CLOSED"
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        self = try FilterOpenStatuses(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
+}

--- a/Modules/Core/Model/Sources/Domain/Response/HomeFilterScreenResponse.swift
+++ b/Modules/Core/Model/Sources/Domain/Response/HomeFilterScreenResponse.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct HomeFilterScreenResponse: Decodable {
+    public let sections: [any HomeScreenSection]
+
+    public enum CodingKeys: String, CodingKey {
+        case sections
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        var sectionsArray = try container.nestedUnkeyedContainer(forKey: .sections)
+        var tempContainer = sectionsArray
+        var sections: [any HomeScreenSection] = []
+
+        while !sectionsArray.isAtEnd {
+            let preview = try sectionsArray.decode(SectionTypePreview.self)
+            let sectionDecoder = try tempContainer.superDecoder()
+
+            switch preview.type {
+            case .homeFilter:
+                sections.append(try HomeFilterSection(from: sectionDecoder))
+            case .unknown:
+                continue
+            }
+        }
+        self.sections = sections
+    }
+}
+
+private struct SectionTypePreview: Decodable {
+    let type: HomeScreenSectionType
+}

--- a/Modules/Core/Model/Sources/ServerDriven/Component/HomeFilterComponents.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Component/HomeFilterComponents.swift
@@ -67,12 +67,14 @@ public struct HomeFilterSection: HomeScreenSection {
 public struct HomeFilterCategoryBar: HomeFilterBar {
     public let type: HomeFilterBarType
     public let categoriesFilter: SDChip
+    public let categoriesFilterClickLog: SDClickLog
     public let currentCategoryFilter: HomeFilterCurrentCategory?
 }
 
 public struct HomeFilterCurrentCategory: Decodable, Hashable {
     public let fontColor: String
     public let style: SDSurfaceStyle
+    public let clickLog: SDClickLog
 }
 
 public struct HomeFilterRadioBar: HomeFilterBar {
@@ -84,11 +86,13 @@ public struct HomeFilterRadioBar: HomeFilterBar {
 public struct HomeFilterRadioOption: Decodable, Hashable {
     public let chip: SDChip
     public let paramValue: String?
+    public let clickLog: SDClickLog?
 }
 
 public struct HomeFilterActionBar: HomeFilterBar {
     public let type: HomeFilterBarType
     public let button: SDButton
+    public let clickLog: SDClickLog
 }
 
 private struct BarTypePreview: Decodable {

--- a/Modules/Core/Model/Sources/ServerDriven/Component/HomeFilterComponents.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Component/HomeFilterComponents.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+public enum HomeScreenSectionType: String, Decodable {
+    case homeFilter = "HOME_FILTER"
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        self = try HomeScreenSectionType(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
+}
+
+public enum HomeFilterBarType: String, Decodable {
+    case categoryBar = "CATEGORY_BAR"
+    case radioBar = "RADIO_BAR"
+    case actionBar = "ACTION_BAR"
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        self = try HomeFilterBarType(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
+}
+
+public protocol HomeScreenSection: Decodable {
+    var type: HomeScreenSectionType { get }
+}
+
+public protocol HomeFilterBar: Decodable, Hashable {
+    var type: HomeFilterBarType { get }
+}
+
+public struct HomeFilterSection: HomeScreenSection {
+    public let type: HomeScreenSectionType
+    public let bars: [any HomeFilterBar]
+
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case bars
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(HomeScreenSectionType.self, forKey: .type)
+
+        var barsArray = try container.nestedUnkeyedContainer(forKey: .bars)
+        var tempContainer = barsArray
+        var bars: [any HomeFilterBar] = []
+
+        while !barsArray.isAtEnd {
+            let preview = try barsArray.decode(BarTypePreview.self)
+            let barDecoder = try tempContainer.superDecoder()
+
+            switch preview.type {
+            case .categoryBar:
+                bars.append(try HomeFilterCategoryBar(from: barDecoder))
+            case .radioBar:
+                bars.append(try HomeFilterRadioBar(from: barDecoder))
+            case .actionBar:
+                bars.append(try HomeFilterActionBar(from: barDecoder))
+            case .unknown:
+                continue
+            }
+        }
+        self.bars = bars
+    }
+}
+
+public struct HomeFilterCategoryBar: HomeFilterBar {
+    public let type: HomeFilterBarType
+    public let categoriesFilter: SDChip
+    public let currentCategoryFilter: HomeFilterCurrentCategory?
+}
+
+public struct HomeFilterCurrentCategory: Decodable, Hashable {
+    public let fontColor: String
+    public let style: SDSurfaceStyle
+}
+
+public struct HomeFilterRadioBar: HomeFilterBar {
+    public let type: HomeFilterBarType
+    public let paramKey: String
+    public let options: [HomeFilterRadioOption]
+}
+
+public struct HomeFilterRadioOption: Decodable, Hashable {
+    public let chip: SDChip
+    public let paramValue: String?
+}
+
+public struct HomeFilterActionBar: HomeFilterBar {
+    public let type: HomeFilterBarType
+    public let button: SDButton
+}
+
+private struct BarTypePreview: Decodable {
+    let type: HomeFilterBarType
+}

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDButton.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDButton.swift
@@ -9,4 +9,10 @@ public struct SDButton: Decodable, Equatable, Hashable {
 
 public struct SDButtonStyle: Decodable, Equatable, Hashable {
     public let backgroundColor: String
+    public let border: SDBorder?
+
+    public init(backgroundColor: String, border: SDBorder? = nil) {
+        self.backgroundColor = backgroundColor
+        self.border = border
+    }
 }

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDChip.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDChip.swift
@@ -14,8 +14,10 @@ public struct SDChip: Decodable, Equatable, Hashable {
 
 public struct SDChipStyle: Decodable, Equatable, Hashable {
     public let backgroundColor: String
+    public let border: SDBorder?
 
-    public init(backgroundColor: String) {
+    public init(backgroundColor: String, border: SDBorder? = nil) {
         self.backgroundColor = backgroundColor
+        self.border = border
     }
 }

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDChip.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDChip.swift
@@ -4,8 +4,18 @@ public struct SDChip: Decodable, Equatable, Hashable {
     public let image: SDImage?
     public let text: SDText
     public let style: SDChipStyle?
+
+    public init(image: SDImage?, text: SDText, style: SDChipStyle?) {
+        self.image = image
+        self.text = text
+        self.style = style
+    }
 }
 
 public struct SDChipStyle: Decodable, Equatable, Hashable {
     public let backgroundColor: String
+
+    public init(backgroundColor: String) {
+        self.backgroundColor = backgroundColor
+    }
 }

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDClickLog.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDClickLog.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public struct SDClickLog: Decodable, Equatable, Hashable {
+    public let screenName: String
+    public let objectType: String
+    public let objectId: String
+    public let extraParameters: [String: SDClickLogValue]
+
+    public init(
+        screenName: String,
+        objectType: String,
+        objectId: String,
+        extraParameters: [String: SDClickLogValue] = [:]
+    ) {
+        self.screenName = screenName
+        self.objectType = objectType
+        self.objectId = objectId
+        self.extraParameters = extraParameters
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.screenName = try container.decode(String.self, forKey: .screenName)
+        self.objectType = try container.decode(String.self, forKey: .objectType)
+        self.objectId = try container.decode(String.self, forKey: .objectId)
+        self.extraParameters = try container.decodeIfPresent(
+            [String: SDClickLogValue].self,
+            forKey: .extraParameters
+        ) ?? [:]
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case screenName
+        case objectType
+        case objectId
+        case extraParameters
+    }
+}
+
+/// SDClickLog.extraParameters 의 값. 서버는 임의 타입을 보낼 수 있어 (string/int/double/bool) 모두 보존한다.
+public enum SDClickLogValue: Decodable, Equatable, Hashable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+            return
+        }
+        // Bool 을 Int 보다 먼저 시도 — JSONDecoder 는 true/false 를 Int 로 디코드하지 않으므로 안전하다.
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+            return
+        }
+        if let value = try? container.decode(Int.self) {
+            self = .int(value)
+            return
+        }
+        if let value = try? container.decode(Double.self) {
+            self = .double(value)
+            return
+        }
+        let value = try container.decode(String.self)
+        self = .string(value)
+    }
+
+    /// GA 파라미터로 직렬화할 때 사용하는 raw 값.
+    public var anyValue: Any? {
+        switch self {
+        case .string(let value): return value
+        case .int(let value): return value
+        case .double(let value): return value
+        case .bool(let value): return value
+        case .null: return nil
+        }
+    }
+}

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDImage.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDImage.swift
@@ -3,9 +3,19 @@ import Foundation
 public struct SDImage: Decodable, Equatable, Hashable {
     public let url: String
     public let style: SDImageStyle
+
+    public init(url: String, style: SDImageStyle) {
+        self.url = url
+        self.style = style
+    }
 }
 
 public struct SDImageStyle: Decodable, Equatable, Hashable {
     public let width: Double
     public let height: Double
+
+    public init(width: Double, height: Double) {
+        self.width = width
+        self.height = height
+    }
 }

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDSurfaceStyle.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDSurfaceStyle.swift
@@ -12,24 +12,13 @@ public struct SDBorder: Decodable, Equatable, Hashable {
 
 public struct SDSurfaceStyle: Decodable, Hashable {
     public let backgroundColor: String
-    /// 서버가 중첩 객체 형태(`border: {color, width}`)로 내려주는 표준 표현.
     public let border: SDBorder?
-    /// flat 형태(`borderColor`, `borderWidth`)로 합성한 legacy 호출자 호환용. 서버 응답에는 보통 없음.
-    public let borderColor: String?
-    public let borderWidth: Double?
-    public let cornerRadius: Double?
 
     public init(
         backgroundColor: String,
-        border: SDBorder? = nil,
-        borderColor: String? = nil,
-        borderWidth: Double? = nil,
-        cornerRadius: Double? = nil
+        border: SDBorder? = nil
     ) {
         self.backgroundColor = backgroundColor
         self.border = border
-        self.borderColor = borderColor
-        self.borderWidth = borderWidth
-        self.cornerRadius = cornerRadius
     }
 }

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDSurfaceStyle.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDSurfaceStyle.swift
@@ -1,18 +1,33 @@
 import Foundation
 
+public struct SDBorder: Decodable, Equatable, Hashable {
+    public let color: String
+    public let width: Double
+
+    public init(color: String, width: Double) {
+        self.color = color
+        self.width = width
+    }
+}
+
 public struct SDSurfaceStyle: Decodable, Hashable {
     public let backgroundColor: String
+    /// 서버가 중첩 객체 형태(`border: {color, width}`)로 내려주는 표준 표현.
+    public let border: SDBorder?
+    /// flat 형태(`borderColor`, `borderWidth`)로 합성한 legacy 호출자 호환용. 서버 응답에는 보통 없음.
     public let borderColor: String?
     public let borderWidth: Double?
     public let cornerRadius: Double?
 
     public init(
         backgroundColor: String,
+        border: SDBorder? = nil,
         borderColor: String? = nil,
         borderWidth: Double? = nil,
         cornerRadius: Double? = nil
     ) {
         self.backgroundColor = backgroundColor
+        self.border = border
         self.borderColor = borderColor
         self.borderWidth = borderWidth
         self.cornerRadius = cornerRadius

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDSurfaceStyle.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDSurfaceStyle.swift
@@ -5,4 +5,16 @@ public struct SDSurfaceStyle: Decodable, Hashable {
     public let borderColor: String?
     public let borderWidth: Double?
     public let cornerRadius: Double?
+
+    public init(
+        backgroundColor: String,
+        borderColor: String? = nil,
+        borderWidth: Double? = nil,
+        cornerRadius: Double? = nil
+    ) {
+        self.backgroundColor = backgroundColor
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
+        self.cornerRadius = cornerRadius
+    }
 }

--- a/Modules/Core/Model/Sources/ServerDriven/Foundation/SDText.swift
+++ b/Modules/Core/Model/Sources/ServerDriven/Foundation/SDText.swift
@@ -4,4 +4,10 @@ public struct SDText: Decodable, Equatable, Hashable {
     public let text: String
     public let isHtml: Bool
     public let fontColor: String
+
+    public init(text: String, isHtml: Bool, fontColor: String) {
+        self.text = text
+        self.isHtml = isHtml
+        self.fontColor = fontColor
+    }
 }

--- a/Modules/Core/Network/Sources/API/ScreenApi.swift
+++ b/Modules/Core/Network/Sources/API/ScreenApi.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+import Model
+
+enum ScreenApi {
+    case fetchHomeFilterScreen
+}
+
+extension ScreenApi: RequestType {
+    var param: (any Encodable)? {
+        switch self {
+        case .fetchHomeFilterScreen:
+            return nil
+        }
+    }
+
+    var method: RequestMethod {
+        switch self {
+        case .fetchHomeFilterScreen:
+            return .get
+        }
+    }
+
+    var header: HTTPHeaderType {
+        switch self {
+        case .fetchHomeFilterScreen:
+            return .json
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .fetchHomeFilterScreen:
+            return "/api/v1/screen/home"
+        }
+    }
+}

--- a/Modules/Core/Network/Sources/Repository/ScreenRepository.swift
+++ b/Modules/Core/Network/Sources/Repository/ScreenRepository.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+import Model
+
+public protocol ScreenRepository {
+    func fetchHomeFilterScreen() async -> Result<HomeFilterScreenResponse, Error>
+}
+
+public final class ScreenRepositoryImpl: ScreenRepository {
+    public init() { }
+
+    public func fetchHomeFilterScreen() async -> Result<HomeFilterScreenResponse, Error> {
+        let request = ScreenApi.fetchHomeFilterScreen
+        return await NetworkManager.shared.request(requestType: request)
+    }
+}

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeView.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeView.swift
@@ -193,7 +193,9 @@ final class HomeView: BaseView {
     }
     
     func showFilterTooltiop(isShow: Bool) {
-        if isShow, let cell = homeFilterCollectionView.cellForItem(at: IndexPath(item: 1, section: 0)) as? HomeFilterCell {
+        if isShow,
+           let indexPath = homeFilterCollectionView.firstRadioCellIndexPath,
+           let cell = homeFilterCollectionView.cellForItem(at: indexPath) as? HomeFilterCell {
             let homeFilterTooltip = HomeFilterTooltip()
             addSubview(homeFilterTooltip)
             homeFilterTooltip.snp.makeConstraints {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -29,6 +29,7 @@ extension HomeViewModel {
         let onTapOnlyBoss = PassthroughSubject<Void, Never>()
         let onTapRadioOption = PassthroughSubject<(paramKey: String, optionIndex: Int), Never>()
         let onTapActionLink = PassthroughSubject<SDLink, Never>()
+        let onTapCloseSelectedCategory = PassthroughSubject<Void, Never>()
         let onTapSearchAddress = PassthroughSubject<Void, Never>()
         let searchByAddress = PassthroughSubject<PlaceDocument, Never>()
         let onTapResearch = PassthroughSubject<Void, Never>()
@@ -143,6 +144,9 @@ final class HomeViewModel: BaseViewModel {
 
     private var state = State()
     private var dependency: Dependency
+    // 필터 응답이 도착하기 전에 home-cards가 먼저 호출되면 dynamicParams가 비어버리므로,
+    // 첫 fetchHomeCards 호출만 위치 + 필터 응답 두 신호가 모두 준비될 때까지 게이팅한다.
+    private let filterScreenLoaded = PassthroughSubject<Void, Never>()
 
     init(dependency: Dependency = Dependency()) {
         self.dependency = dependency
@@ -190,6 +194,14 @@ final class HomeViewModel: BaseViewModel {
                 owner.state.newCameraPosition = location
                 owner.output.cameraPosition.send(location)
                 owner.dependency.preference.userCurrentLocation = location
+            })
+            .store(in: &cancellables)
+
+        // 첫 home-cards 요청은 위치 + 필터 응답이 모두 준비된 뒤에만 발사한다.
+        Publishers.CombineLatest(getCurrentLocation, filterScreenLoaded)
+            .first()
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeViewModel, _) in
                 owner.fetchHomeCards()
             })
             .store(in: &cancellables)
@@ -282,7 +294,16 @@ final class HomeViewModel: BaseViewModel {
         input.onTapActionLink
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, link: SDLink) in
+                owner.sendActionBarClickLog(for: link)
                 owner.output.route.send(.deepLink(link))
+            })
+            .store(in: &cancellables)
+
+        input.onTapCloseSelectedCategory
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeViewModel, _) in
+                owner.sendCurrentCategoryCloseLog()
+                owner.input.selectCategory.send(nil)
             })
             .store(in: &cancellables)
 
@@ -509,14 +530,6 @@ final class HomeViewModel: BaseViewModel {
             categoryIds = [filterCategory.categoryId]
         }
 
-        let openStatuses: [FilterOpenStatuses]? = currentParamValue(for: "filterOpenStatuses")
-            .flatMap(FilterOpenStatuses.init(rawValue:))
-            .map { [$0] }
-        let filterConditions: [ActivitiesStatus] = (currentParamValue(for: "filterConditions") != nil)
-            ? [.recentActivity]
-            : [.recentActivity, .noRecentActivity]
-        let sortType: StoreSortType = currentParamValue(for: "sortType")
-            .flatMap(StoreSortType.init(rawValue:)) ?? .distanceAsc
         let targetStores: [StoreType] = (currentParamValue(for: "targetStores") == "BOSS_STORE")
             ? [.bossStore]
             : [.userStore, .bossStore]
@@ -525,15 +538,29 @@ final class HomeViewModel: BaseViewModel {
             distanceM: state.mapMaxDistance ?? 0,
             categoryIds: categoryIds,
             targetStores: targetStores,
-            sortType: sortType,
-            filterCertifiedStores: false,
-            filterOpenStatuses: openStatuses,
-            filterConditions: filterConditions,
             size: 10,
             cursor: nil,
             mapLatitude: state.resultCameraPosition?.coordinate.latitude ?? 0,
-            mapLongitude: state.resultCameraPosition?.coordinate.longitude ?? 0
+            mapLongitude: state.resultCameraPosition?.coordinate.longitude ?? 0,
+            dynamicParams: collectDynamicParams()
         )
+    }
+
+    private func collectDynamicParams() -> [String: String] {
+        var params: [String: String] = [:]
+        for case let radioBar as HomeFilterRadioBar in allBars {
+            // targetStores 는 정적 필드로 직렬화되므로 dynamicParams 에서 제외해 중복 쿼리 키를 막는다.
+            guard radioBar.paramKey != "targetStores" else { continue }
+            let selectedIndex = state.radioSelection[radioBar.paramKey] ?? 0
+            guard let option = radioBar.options[safe: selectedIndex],
+                  let paramValue = option.paramValue else { continue }
+            params[radioBar.paramKey] = paramValue
+        }
+        // sortType 은 서버 required 필드. SDU 응답이 비었거나 sortType 라디오바가 없는 경우 기본값으로 보강.
+        if params["sortType"] == nil {
+            params["sortType"] = state.sortType.rawValue
+        }
+        return params
     }
 
     private func currentParamValue(for paramKey: String) -> String? {
@@ -569,20 +596,13 @@ final class HomeViewModel: BaseViewModel {
     }
 
     private func bindHomeListViewModel(_ viewModel: HomeListViewModel) {
-        viewModel.output.onToggleSort
-            .subscribe(input.onToggleSort)
-            .store(in: &viewModel.cancellables)
-
-        viewModel.output.onTapOnlyBoss
-            .subscribe(input.onTapOnlyBoss)
-            .store(in: &viewModel.cancellables)
-
         viewModel.output.onSelectCategoryFilter
             .subscribe(input.selectCategory)
             .store(in: &viewModel.cancellables)
 
-        viewModel.output.onTapOnlyRecentActivity
-            .subscribe(input.onTapOnlyRecentActivity)
+        // 리스트에서 SDU 라디오를 토글하면 홈도 동일 paramKey/optionIndex 로 갱신해 chip · home-cards 가 싱크된다.
+        viewModel.output.onTapRadioOption
+            .subscribe(input.onTapRadioOption)
             .store(in: &viewModel.cancellables)
     }
 
@@ -678,11 +698,11 @@ final class HomeViewModel: BaseViewModel {
     private func presentListView() {
         let config = HomeListViewModel.Config(
             categoryFilter: state.categoryFilter,
-            isOnlyRecentActivity: state.isOnlyRecentActivity,
-            sortType: state.sortType,
             isOnlyBossStore: state.isOnlyBossStore,
             mapLocation: state.resultCameraPosition,
-            mapMaxDistance: state.mapMaxDistance
+            mapMaxDistance: state.mapMaxDistance,
+            filterSections: state.filterSections,
+            radioSelection: state.radioSelection
         )
         let viewModel = HomeListViewModel(config: config)
         bindHomeListViewModel(viewModel)
@@ -712,6 +732,8 @@ extension HomeViewModel {
             case .failure:
                 output.filterDatasource.send(makeFallbackFilterDatasource())
             }
+            // 성공/실패와 무관하게 게이팅을 풀어 첫 fetchHomeCards 가 진행되도록 한다.
+            filterScreenLoaded.send()
         }
         .store(in: taskBag)
     }
@@ -736,6 +758,29 @@ extension HomeViewModel {
               let option = radioBar.options[safe: optionIndex] else { return }
         state.radioSelection[paramKey] = optionIndex
         applyParamValueToLegacyState(paramKey: paramKey, paramValue: option.paramValue)
+        sendClickFilterLog(option: option)
+    }
+
+    private func sendClickFilterLog(option: HomeFilterRadioOption) {
+        guard let clickLog = option.clickLog else { return }
+        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+    }
+
+    private func sendActionBarClickLog(for link: SDLink) {
+        let actionBar = allBars
+            .compactMap { $0 as? HomeFilterActionBar }
+            .first { $0.button.link == link }
+        guard let clickLog = actionBar?.clickLog else { return }
+        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+    }
+
+    private func sendCurrentCategoryCloseLog() {
+        let currentCategory = allBars
+            .compactMap { $0 as? HomeFilterCategoryBar }
+            .first?
+            .currentCategoryFilter
+        guard let clickLog = currentCategory?.clickLog else { return }
+        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
     }
 
     private func applyParamValueToLegacyState(paramKey: String, paramValue: String?) {
@@ -788,8 +833,9 @@ extension HomeViewModel {
             case let categoryBar as HomeFilterCategoryBar:
                 cells.append(.chip(categoryBar.categoriesFilter, surface: nil, action: .openCategoryFilter))
                 if let category = state.categoryFilter {
-                    let chip = makeSelectedCategoryChip(category: category, fontColor: "#000000")
-                    cells.append(.selectedCategoryChip(chip))
+                    let fontColor = categoryBar.currentCategoryFilter?.fontColor ?? "#000000"
+                    let chip = makeSelectedCategoryChip(category: category, fontColor: fontColor)
+                    cells.append(.selectedCategoryChip(chip, current: categoryBar.currentCategoryFilter))
                 }
             case let radioBar as HomeFilterRadioBar:
                 let selectedIndex = state.radioSelection[radioBar.paramKey] ?? 0
@@ -837,7 +883,7 @@ extension HomeViewModel {
         ]
         if let category = state.categoryFilter {
             let chip = makeSelectedCategoryChip(category: category, fontColor: "#000000")
-            cells.append(.selectedCategoryChip(chip))
+            cells.append(.selectedCategoryChip(chip, current: nil))
         }
         return cells
     }
@@ -879,6 +925,13 @@ extension HomeViewModel {
     }
 
     private func sendClickCategoryFilterLog() {
+        if let clickLog = allBars
+            .compactMap({ $0 as? HomeFilterCategoryBar })
+            .first?
+            .categoriesFilterClickLog {
+            dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+            return
+        }
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
             objectType: .button,
@@ -959,6 +1012,10 @@ extension HomeViewModel: HomeFilterSelectable {
 
     var onTapActionLink: PassthroughSubject<SDLink, Never> {
         input.onTapActionLink
+    }
+
+    var onTapCloseSelectedCategory: PassthroughSubject<Void, Never> {
+        input.onTapCloseSelectedCategory
     }
 
     var selectCategory: PassthroughSubject<StoreFoodCategoryResponse?, Never> {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -15,7 +15,7 @@ extension HomeViewModel {
     enum Constant {
         static let defaultLocation = CLLocation(latitude: 37.497941, longitude: 127.027616) // 강남역
     }
-    
+
     struct Input {
         let viewDidLoad = PassthroughSubject<Void, Never>()
         let onLoadFilter = PassthroughSubject<Void, Never>()
@@ -27,6 +27,8 @@ extension HomeViewModel {
         let onTapOnlyRecentActivity = PassthroughSubject<Void, Never>()
         let onToggleSort = PassthroughSubject<StoreSortType, Never>()
         let onTapOnlyBoss = PassthroughSubject<Void, Never>()
+        let onTapRadioOption = PassthroughSubject<(paramKey: String, optionIndex: Int), Never>()
+        let onTapActionLink = PassthroughSubject<SDLink, Never>()
         let onTapSearchAddress = PassthroughSubject<Void, Never>()
         let searchByAddress = PassthroughSubject<PlaceDocument, Never>()
         let onTapResearch = PassthroughSubject<Void, Never>()
@@ -37,20 +39,15 @@ extension HomeViewModel {
         let onTapMarker = PassthroughSubject<Int, Never>()
         let onTapCurrentMarker = PassthroughSubject<Void, Never>()
         let didTapFeedButton = PassthroughSubject<Void, Never>()
-        
+
         // From SubViewModel
         let didTapCardActionButton = PassthroughSubject<SDLink, Never>()
     }
-    
+
     struct Output {
         let screenName: ScreenName = .home
         let address = PassthroughSubject<String, Never>()
-        let filterDatasource = CurrentValueSubject<[HomeFilterCollectionView.CellType], Never>([
-            .category(nil),
-            .recentActivity(true),
-            .sortingFilter(.distanceAsc),
-            .onlyBoss(false)
-        ])
+        let filterDatasource = CurrentValueSubject<[HomeFilterCollectionView.CellType], Never>([])
         let isHiddenResearchButton = PassthroughSubject<Bool, Never>()
         let cameraPosition = PassthroughSubject<CLLocation, Never>()
         let advertisementMarker = PassthroughSubject<AdvertisementResponse, Never>()
@@ -60,7 +57,7 @@ extension HomeViewModel {
         let showLoading = PassthroughSubject<Bool, Never>()
         let route = PassthroughSubject<Route, Never>()
     }
-    
+
     struct State {
         var address = ""
         var categoryFilter: StoreFoodCategoryResponse?
@@ -68,6 +65,10 @@ extension HomeViewModel {
         var sortType: StoreSortType = .distanceAsc
         var isOnlyBossStore = false
         var isOnlyRecentActivity = true
+        var openStatuses: [FilterOpenStatuses]?
+        var filterSections: [any HomeScreenSection] = []
+        var radioSelection: [String: Int] = [:]
+        var hasLoadedFilterScreen = false
         var mapMaxDistance: Double?
         var newCameraPosition: CLLocation?
         var newMapMaxDistance: Double?
@@ -76,10 +77,10 @@ extension HomeViewModel {
         var advertisementMarker: AdvertisementResponse?
         var selectedIndex = 0
         var hasMore: Bool = true
-        var nextCursor: String? = nil
+        var nextCursor: String?
         var user: UserDetailResponse?
     }
-    
+
     enum Route {
         case presentCategoryFilter(CategoryFilterViewModel)
         case presentListView(HomeListViewModel)
@@ -92,9 +93,10 @@ extension HomeViewModel {
         case presentAccountInfo(BaseViewModel)
         case presentFeedList(FeedListViewModel)
     }
-    
+
     struct Dependency {
         let homeRepository: HomeRepository
+        let screenRepository: ScreenRepository
         let advertisementRepository: AdvertisementRepository
         let userRepository: UserRepository
         let mapRepository: MapRepository
@@ -102,9 +104,10 @@ extension HomeViewModel {
         var preference: Preference
         let logManager: LogManagerProtocol
         let appModuleInterface: AppModuleInterface
-        
+
         init(
             homeRepository: HomeRepository = HomeRepositoryImpl(),
+            screenRepository: ScreenRepository = ScreenRepositoryImpl(),
             advertisementRepository: AdvertisementRepository = AdvertisementRepositoryImpl(),
             userRepository: UserRepository = UserRepositoryImpl(),
             mapRepository: MapRepository = MapRepositoryImpl(),
@@ -114,6 +117,7 @@ extension HomeViewModel {
             appModuleInterface: AppModuleInterface = Environment.appModuleInterface
         ) {
             self.homeRepository = homeRepository
+            self.screenRepository = screenRepository
             self.advertisementRepository = advertisementRepository
             self.userRepository = userRepository
             self.mapRepository = mapRepository
@@ -128,31 +132,31 @@ extension HomeViewModel {
 final class HomeViewModel: BaseViewModel {
     let input = Input()
     let output = Output()
-    
+
     var currentAddress: String {
         state.address
     }
-    
+
     var focusedPosition: CLLocation? {
         state.newCameraPosition
     }
-    
+
     private var state = State()
     private var dependency: Dependency
-    
+
     init(dependency: Dependency = Dependency()) {
         self.dependency = dependency
-        
+
         super.init()
     }
-    
+
     override func bind() {
         input.onMapLoad
             .sink { [weak self] _ in
                 self?.fetchAdvertisementMarker()
             }
             .store(in: &cancellables)
-        
+
         let getCurrentLocation = input.onMapLoad
             .withUnretained(self)
             .handleEvents(receiveOutput: { owner, distance in
@@ -164,12 +168,12 @@ final class HomeViewModel: BaseViewModel {
                     .catch { error -> AnyPublisher<CLLocation, Never> in
                         owner.output.showLoading.send(false)
                         owner.output.route.send(.showErrorAlert(error))
-                        
+
                         return Just(Constant.defaultLocation).eraseToAnyPublisher()
                     }
             }
             .share()
-        
+
         getCurrentLocation
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, location: CLLocation) in
@@ -177,7 +181,7 @@ final class HomeViewModel: BaseViewModel {
                 owner.fetchAddress(location: location)
             })
             .store(in: &cancellables)
-        
+
         getCurrentLocation
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, location: CLLocation) in
@@ -189,27 +193,28 @@ final class HomeViewModel: BaseViewModel {
                 owner.fetchHomeCards()
             })
             .store(in: &cancellables)
-                
+
         input.viewDidLoad
             .sink(receiveValue: { [weak self] in
                 self?.presentPolicyIfNeeded()
+                self?.fetchFilterScreen()
             })
             .store(in: &cancellables)
-        
+
         input.changeMaxDistance
             .sink { [weak self] distance in
                 self?.state.newMapMaxDistance = distance
                 self?.output.isHiddenResearchButton.send(false)
             }
             .store(in: &cancellables)
-        
+
         input.changeMapLocation
             .sink { [weak self] location in
                 self?.state.newCameraPosition = location
                 self?.output.isHiddenResearchButton.send(false)
             }
             .store(in: &cancellables)
-        
+
         input.onTapCategoryFilter
             .sink(receiveValue: { [weak self] _ in
                 self?.hiddenTooltip()
@@ -217,7 +222,7 @@ final class HomeViewModel: BaseViewModel {
                 self?.presentCategoryFilter()
             })
             .store(in: &cancellables)
-        
+
         input.selectCategory
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, category: StoreFoodCategoryResponse?) in
@@ -227,40 +232,60 @@ final class HomeViewModel: BaseViewModel {
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onTapOnlyRecentActivity
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, _) in
                 owner.hiddenTooltip()
                 owner.state.isOnlyRecentActivity.toggle()
                 owner.sendClickRecentActivityFilter(isOn: owner.state.isOnlyRecentActivity)
+                owner.syncRadioSelectionFromLegacy()
                 owner.fetchHomeCards()
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onToggleSort
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, sortType: StoreSortType) in
                 owner.hiddenTooltip()
                 owner.state.sortType = owner.state.sortType.toggled()
                 owner.sendClickSortingFilterLog(sortType: sortType)
+                owner.syncRadioSelectionFromLegacy()
                 owner.fetchHomeCards()
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onTapOnlyBoss
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, _) in
                 owner.hiddenTooltip()
                 owner.state.isOnlyBossStore.toggle()
                 owner.sendClickOnlyBossFilterLog(isOn: owner.state.isOnlyBossStore)
+                owner.syncRadioSelectionFromLegacy()
                 owner.fetchHomeCards()
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
+        input.onTapRadioOption
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeViewModel, payload: (paramKey: String, optionIndex: Int)) in
+                owner.hiddenTooltip()
+                owner.applyRadioSelection(paramKey: payload.paramKey, optionIndex: payload.optionIndex)
+                owner.fetchHomeCards()
+                owner.updateFilterDatasource()
+            })
+            .store(in: &cancellables)
+
+        input.onTapActionLink
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeViewModel, link: SDLink) in
+                owner.output.route.send(.deepLink(link))
+            })
+            .store(in: &cancellables)
+
         input.onTapSearchAddress
             .withUnretained(self)
             .sink { (owner: HomeViewModel, _) in
@@ -268,13 +293,13 @@ final class HomeViewModel: BaseViewModel {
                 owner.presentSearchAddress()
             }
             .store(in: &cancellables)
-        
+
         input.searchByAddress
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, placeDocument: PlaceDocument) in
                 owner.state.address = placeDocument.placeName
                 owner.output.address.send(placeDocument.placeName)
-                
+
                 let latitude = Double(placeDocument.y) ?? 0
                 let longitude = Double(placeDocument.x) ?? 0
                 let location = CLLocation(latitude: latitude, longitude: longitude)
@@ -285,7 +310,7 @@ final class HomeViewModel: BaseViewModel {
                 owner.output.isHiddenResearchButton.send(true)
             })
             .store(in: &cancellables)
-        
+
         input.onTapResearch
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeViewModel, _) in
@@ -296,13 +321,13 @@ final class HomeViewModel: BaseViewModel {
                 owner.output.isHiddenResearchButton.send(true)
             })
             .store(in: &cancellables)
-        
+
         input.onTapResearch
             .withUnretained(self)
             .asyncMap { owner, _ in
                 let latitude = owner.state.newCameraPosition?.coordinate.latitude ?? Constant.defaultLocation.coordinate.latitude
                 let longitude = owner.state.newCameraPosition?.coordinate.longitude ?? Constant.defaultLocation.coordinate.longitude
-                
+
                 return await owner.dependency.mapRepository.getAddressFromLocation(
                     latitude: latitude,
                     longitude: longitude
@@ -314,14 +339,13 @@ final class HomeViewModel: BaseViewModel {
                 case .success(let address):
                     owner.state.address = address
                     owner.output.address.send(address)
-                    
+
                 case .failure(let error):
                     owner.output.route.send(.showErrorAlert(error))
                 }
             }
             .store(in: &cancellables)
-            
-        
+
         input.onTapCurrentLocation
             .withUnretained(self)
             .flatMap { owner, _ in
@@ -339,16 +363,16 @@ final class HomeViewModel: BaseViewModel {
                 owner.output.cameraPosition.send(location)
             }
             .store(in: &cancellables)
-        
+
         input.onTapListView
             .sink(receiveValue: { [weak self] _ in
                 self?.presentListView()
             })
             .store(in: &cancellables)
-        
+
         input.selectStore
             .withLatestFrom(output.datasource) { ($0, $1) }
-            .handleEvents(receiveOutput: { [weak self] (index: Int, items: [HomeCardSectionItem]) in
+            .handleEvents(receiveOutput: { [weak self] (index: Int, _: [HomeCardSectionItem]) in
                 self?.output.scrollToIndex.send(index)
                 self?.state.selectedIndex = index
             })
@@ -364,7 +388,7 @@ final class HomeViewModel: BaseViewModel {
                 }
             })
             .store(in: &cancellables)
-        
+
         input.onTapMarker
             .withLatestFrom(output.datasource) { ($0, $1) }
             .sink(receiveValue: { [weak self] (index: Int, items: [HomeCardSectionItem]) in
@@ -381,13 +405,13 @@ final class HomeViewModel: BaseViewModel {
                 output.scrollToIndex.send(index)
             })
             .store(in: &cancellables)
-        
+
         input.onTapStore
             .withLatestFrom(output.datasource) { ($0, $1) }
             .sink(receiveValue: { [weak self] (index: Int, items: [HomeCardSectionItem]) in
                 guard let self,
                       let item = items[safe: index] else { return }
-                
+
                 if index == state.selectedIndex {
                     routeCard(item)
                 } else {
@@ -395,7 +419,7 @@ final class HomeViewModel: BaseViewModel {
                 }
             })
             .store(in: &cancellables)
-        
+
         input.onTapCurrentMarker
             .filter { [weak self] in
                 return self?.state.advertisementMarker != nil
@@ -408,17 +432,17 @@ final class HomeViewModel: BaseViewModel {
             })
             .subscribe(output.route)
             .store(in: &cancellables)
-        
+
         input.onLoadFilter
             .sink { [weak self] _ in
                 self?.showFilterTooltipIfNeeded()
             }
             .store(in: &cancellables)
-        
+
         input.didTapFeedButton
             .withUnretained(self)
             .sink { (owner: HomeViewModel, _) in
-                let mapLocation = owner.state.newCameraPosition ?? owner.state.currentLocation 
+                let mapLocation = owner.state.newCameraPosition ?? owner.state.currentLocation
                 let config = FeedListViewModelConfig(
                     mapLatitude: mapLocation?.coordinate.latitude,
                     mapLongitude: mapLocation?.coordinate.longitude
@@ -428,25 +452,14 @@ final class HomeViewModel: BaseViewModel {
                 owner.output.route.send(.presentFeedList(viewModel))
             }
             .store(in: &cancellables)
-        
+
         input.didTapCardActionButton
             .sink { [weak self] link in
                 self?.output.route.send(.deepLink(link))
             }
             .store(in: &cancellables)
     }
-    
-    private func updateFilterDatasource() {
-        let datasource: [HomeFilterCollectionView.CellType] = [
-            .category(state.categoryFilter),
-            .recentActivity(state.isOnlyRecentActivity),
-            .sortingFilter(state.sortType),
-            .onlyBoss(state.isOnlyBossStore)
-        ]
-        
-        output.filterDatasource.send(datasource)
-    }
-    
+
     private func updateDatasource() {
         var datasource: [HomeCardSectionItem] = []
         for component in state.homeCardComponents {
@@ -461,21 +474,21 @@ final class HomeViewModel: BaseViewModel {
                 datasource.append(.admob(data))
             }
         }
-        
+
         if datasource.isEmpty {
             datasource = [.empty]
         }
-        
+
         output.datasource.send(datasource)
         output.scrollToIndex.send(0)
     }
-    
+
     private func fetchHomeCards() {
         Task {
             output.showLoading.send(true)
             let input = createFetchHomeCardInput()
             let result = await dependency.homeRepository.fetchHomeCards(input: input)
-            
+
             switch result {
             case .success(let response):
                 state.nextCursor = response.cursor?.nextCursor
@@ -489,20 +502,32 @@ final class HomeViewModel: BaseViewModel {
         }
         .store(in: taskBag)
     }
-    
+
     private func createFetchHomeCardInput() -> FetchHomeCardInput {
-        var categoryIds: [String]? = nil
+        var categoryIds: [String]?
         if let filterCategory = state.categoryFilter {
             categoryIds = [filterCategory.categoryId]
         }
-        let targetStores: [StoreType] = state.isOnlyBossStore ? [.bossStore] : [.userStore, .bossStore]
-        let filterConditions: [ActivitiesStatus] = state.isOnlyRecentActivity ? [.recentActivity] : [.recentActivity, .noRecentActivity]
+
+        let openStatuses: [FilterOpenStatuses]? = currentParamValue(for: "filterOpenStatuses")
+            .flatMap(FilterOpenStatuses.init(rawValue:))
+            .map { [$0] }
+        let filterConditions: [ActivitiesStatus] = (currentParamValue(for: "filterConditions") != nil)
+            ? [.recentActivity]
+            : [.recentActivity, .noRecentActivity]
+        let sortType: StoreSortType = currentParamValue(for: "sortType")
+            .flatMap(StoreSortType.init(rawValue:)) ?? .distanceAsc
+        let targetStores: [StoreType] = (currentParamValue(for: "targetStores") == "BOSS_STORE")
+            ? [.bossStore]
+            : [.userStore, .bossStore]
+
         return FetchHomeCardInput(
             distanceM: state.mapMaxDistance ?? 0,
             categoryIds: categoryIds,
             targetStores: targetStores,
-            sortType: state.sortType,
+            sortType: sortType,
             filterCertifiedStores: false,
+            filterOpenStatuses: openStatuses,
             filterConditions: filterConditions,
             size: 10,
             cursor: nil,
@@ -510,52 +535,63 @@ final class HomeViewModel: BaseViewModel {
             mapLongitude: state.resultCameraPosition?.coordinate.longitude ?? 0
         )
     }
-    
+
+    private func currentParamValue(for paramKey: String) -> String? {
+        guard
+            let radioBar = (allBars.first { ($0 as? HomeFilterRadioBar)?.paramKey == paramKey }) as? HomeFilterRadioBar,
+            let idx = state.radioSelection[paramKey],
+            let option = radioBar.options[safe: idx]
+        else {
+            return legacyParamValue(for: paramKey)
+        }
+        return option.paramValue
+    }
+
     private func fetchAdvertisementMarker() {
         Task {
             let input = FetchAdvertisementInput(position: .storeMarker, size: nil)
             let response = await dependency.advertisementRepository.fetchAdvertisements(input: input).data
-            
+
             guard let advertisement = response?.advertisements.first else { return }
             state.advertisementMarker = advertisement
             output.advertisementMarker.send(advertisement)
         }
         .store(in: taskBag)
     }
-    
+
     private func presentSearchAddress() {
         let viewModel = SearchAddressViewModel()
         viewModel.output.selectAddress
             .subscribe(input.searchByAddress)
             .store(in: &viewModel.cancellables)
-        
+
         output.route.send(.presentSearchAddress(viewModel))
     }
-    
+
     private func bindHomeListViewModel(_ viewModel: HomeListViewModel) {
         viewModel.output.onToggleSort
             .subscribe(input.onToggleSort)
             .store(in: &viewModel.cancellables)
-        
+
         viewModel.output.onTapOnlyBoss
             .subscribe(input.onTapOnlyBoss)
             .store(in: &viewModel.cancellables)
-        
+
         viewModel.output.onSelectCategoryFilter
             .subscribe(input.selectCategory)
             .store(in: &viewModel.cancellables)
-        
+
         viewModel.output.onTapOnlyRecentActivity
             .subscribe(input.onTapOnlyRecentActivity)
             .store(in: &viewModel.cancellables)
     }
-    
+
     private func hiddenTooltip() {
         guard dependency.preference.isShownFilterTooltip.isNot else { return }
         dependency.preference.isShownFilterTooltip = true
         output.isShowFilterTooltip.send(false)
     }
-    
+
     private func fetchAddress(location: CLLocation) {
         Task {
             let result = await dependency.mapRepository.getAddressFromLocation(
@@ -573,48 +609,48 @@ final class HomeViewModel: BaseViewModel {
         }
         .store(in: taskBag)
     }
-    
+
     private func presentCategoryFilter() {
         let config = CategoryFilterViewModel.Config(currentCategory: state.categoryFilter)
         let viewModel = CategoryFilterViewModel(config: config)
-        
+
         viewModel.output.didSelectCategory
             .subscribe(input.selectCategory)
             .store(in: &viewModel.cancellables)
         output.route.send(.presentCategoryFilter(viewModel))
     }
-    
+
     private func presentPolicyIfNeeded() {
         Task {
             let user = await dependency.userRepository.fetchUser().data
-            
+
             guard
                 let user,
                 MarketingConsent(value: user.settings.marketingConsent) == .unverified
             else {
                 return
             }
-            
+
             output.route.send(.presentPolicy)
         }.store(in: taskBag)
     }
-    
+
     private func showFilterTooltipIfNeeded() {
         guard dependency.preference.isShownFilterTooltip.isNot else { return }
         output.isShowFilterTooltip.send(true)
     }
-    
+
     private func selectCard(_ item: HomeCardSectionItem, index: Int) {
         if case .store(let cellViewModel) = item,
            let location = cellViewModel.output.data.marker?.location {
             let cameraPosition = CLLocation(latitude: location.latitude, longitude: location.longitude)
             output.cameraPosition.send(cameraPosition)
         }
-        
+
         output.scrollToIndex.send(index)
         state.selectedIndex = index
     }
-    
+
     private func routeCard(_ item: HomeCardSectionItem) {
         switch item {
         case .store(let cellViewModel):
@@ -631,14 +667,14 @@ final class HomeViewModel: BaseViewModel {
             break
         }
     }
-    
+
     private func didTapCardButton(_ component: any HomeCardComponent) {
         guard let component = component as? HomeAdCardSectionResponse,
               let link = component.link else { return }
-        
+
         output.route.send(.deepLink(link))
     }
-    
+
     private func presentListView() {
         let config = HomeListViewModel.Config(
             categoryFilter: state.categoryFilter,
@@ -651,6 +687,159 @@ final class HomeViewModel: BaseViewModel {
         let viewModel = HomeListViewModel(config: config)
         bindHomeListViewModel(viewModel)
         output.route.send(.presentListView(viewModel))
+    }
+}
+
+// MARK: SDUI Filter
+extension HomeViewModel {
+    private func updateFilterDatasource() {
+        let datasource = state.hasLoadedFilterScreen
+            ? flattenFilterDatasource()
+            : makeFallbackFilterDatasource()
+        output.filterDatasource.send(datasource)
+    }
+
+    private func fetchFilterScreen() {
+        Task { @MainActor in
+            let result = await dependency.screenRepository.fetchHomeFilterScreen()
+            switch result {
+            case .success(let response):
+                state.filterSections = response.sections
+                state.hasLoadedFilterScreen = true
+                initializeRadioSelectionDefaults()
+                syncRadioSelectionFromLegacy()
+                output.filterDatasource.send(flattenFilterDatasource())
+            case .failure:
+                output.filterDatasource.send(makeFallbackFilterDatasource())
+            }
+        }
+        .store(in: taskBag)
+    }
+
+    private var allBars: [any HomeFilterBar] {
+        state.filterSections
+            .compactMap { $0 as? HomeFilterSection }
+            .flatMap(\.bars)
+    }
+
+    private func initializeRadioSelectionDefaults() {
+        for case let radioBar as HomeFilterRadioBar in allBars where state.radioSelection[radioBar.paramKey] == nil {
+            state.radioSelection[radioBar.paramKey] = 0
+            if let firstOption = radioBar.options.first {
+                applyParamValueToLegacyState(paramKey: radioBar.paramKey, paramValue: firstOption.paramValue)
+            }
+        }
+    }
+
+    private func applyRadioSelection(paramKey: String, optionIndex: Int) {
+        guard let radioBar = (allBars.first { ($0 as? HomeFilterRadioBar)?.paramKey == paramKey }) as? HomeFilterRadioBar,
+              let option = radioBar.options[safe: optionIndex] else { return }
+        state.radioSelection[paramKey] = optionIndex
+        applyParamValueToLegacyState(paramKey: paramKey, paramValue: option.paramValue)
+    }
+
+    private func applyParamValueToLegacyState(paramKey: String, paramValue: String?) {
+        switch paramKey {
+        case "filterOpenStatuses":
+            if let value = paramValue, let status = FilterOpenStatuses(rawValue: value) {
+                state.openStatuses = [status]
+            } else {
+                state.openStatuses = nil
+            }
+        case "filterConditions":
+            state.isOnlyRecentActivity = (paramValue != nil)
+        case "sortType":
+            state.sortType = paramValue.flatMap(StoreSortType.init(rawValue:)) ?? .distanceAsc
+        case "targetStores":
+            state.isOnlyBossStore = (paramValue == "BOSS_STORE")
+        default:
+            break
+        }
+    }
+
+    private func syncRadioSelectionFromLegacy() {
+        for case let radioBar as HomeFilterRadioBar in allBars {
+            let targetValue: String? = legacyParamValue(for: radioBar.paramKey)
+            if let idx = radioBar.options.firstIndex(where: { $0.paramValue == targetValue }) {
+                state.radioSelection[radioBar.paramKey] = idx
+            }
+        }
+    }
+
+    private func legacyParamValue(for paramKey: String) -> String? {
+        switch paramKey {
+        case "filterOpenStatuses":
+            return state.openStatuses?.first?.rawValue
+        case "filterConditions":
+            return state.isOnlyRecentActivity ? "RECENT_ACTIVITY" : nil
+        case "sortType":
+            return state.sortType.rawValue
+        case "targetStores":
+            return state.isOnlyBossStore ? "BOSS_STORE" : nil
+        default:
+            return nil
+        }
+    }
+
+    private func flattenFilterDatasource() -> [HomeFilterCollectionView.CellType] {
+        var cells: [HomeFilterCollectionView.CellType] = []
+        for bar in allBars {
+            switch bar {
+            case let categoryBar as HomeFilterCategoryBar:
+                cells.append(.chip(categoryBar.categoriesFilter, surface: nil, action: .openCategoryFilter))
+                if let category = state.categoryFilter {
+                    let chip = makeSelectedCategoryChip(category: category, fontColor: "#000000")
+                    cells.append(.selectedCategoryChip(chip))
+                }
+            case let radioBar as HomeFilterRadioBar:
+                let selectedIndex = state.radioSelection[radioBar.paramKey] ?? 0
+                guard radioBar.options.isEmpty.isNot,
+                      let currentOption = radioBar.options[safe: selectedIndex] else { break }
+                let nextIndex = (selectedIndex + 1) % radioBar.options.count
+                let surface: SDSurfaceStyle? = selectedIndex == 0 ? nil : selectedSurface(for: currentOption.chip)
+                let action = HomeFilterCollectionView.ChipAction.selectRadio(paramKey: radioBar.paramKey, optionIndex: nextIndex)
+                cells.append(.chip(currentOption.chip, surface: surface, action: action))
+            case let actionBar as HomeFilterActionBar:
+                cells.append(.button(actionBar.button, surface: nil))
+            default:
+                break
+            }
+        }
+        return cells
+    }
+
+    private func selectedSurface(for chip: SDChip) -> SDSurfaceStyle? {
+        guard let background = chip.style?.backgroundColor else { return nil }
+        return SDSurfaceStyle(
+            backgroundColor: background,
+            borderColor: chip.text.fontColor,
+            borderWidth: 1,
+            cornerRadius: 10
+        )
+    }
+
+    private func makeSelectedCategoryChip(category: StoreFoodCategoryResponse, fontColor: String) -> SDChip {
+        SDChip(
+            image: SDImage(url: category.imageUrl, style: SDImageStyle(width: 16, height: 16)),
+            text: SDText(text: category.name, isHtml: false, fontColor: fontColor),
+            style: nil
+        )
+    }
+
+    private func makeFallbackFilterDatasource() -> [HomeFilterCollectionView.CellType] {
+        let categoriesChip = SDChip(
+            image: nil,
+            text: SDText(text: "음식 종류", isHtml: false, fontColor: "#5A5A5A"),
+            style: nil
+        )
+        var cells: [HomeFilterCollectionView.CellType] = [
+            .chip(categoriesChip, surface: nil, action: .openCategoryFilter)
+        ]
+        if let category = state.categoryFilter {
+            let chip = makeSelectedCategoryChip(category: category, fontColor: "#000000")
+            cells.append(.selectedCategoryChip(chip))
+        }
+        return cells
     }
 }
 
@@ -672,7 +861,7 @@ extension HomeViewModel {
             objectId: .store
         ))
     }
-    
+
     private func sendClickCurrentLocationLog() {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -680,7 +869,7 @@ extension HomeViewModel {
             objectId: .currentLocation
         ))
     }
-    
+
     private func sendClickAddressLog() {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -688,7 +877,7 @@ extension HomeViewModel {
             objectId: .address
         ))
     }
-    
+
     private func sendClickCategoryFilterLog() {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -696,7 +885,7 @@ extension HomeViewModel {
             objectId: .categoryFilter
         ))
     }
-    
+
     private func sendClickOnlyBossFilterLog(isOn: Bool) {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -705,7 +894,7 @@ extension HomeViewModel {
             extraParameters: [.value: isOn]
         ))
     }
-    
+
     private func sendClickSortingFilterLog(sortType: StoreSortType) {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -714,7 +903,7 @@ extension HomeViewModel {
             extraParameters: [.value: sortType.rawValue]
         ))
     }
-    
+
     private func sendClickAdCard(advertisement: AdvertisementReference) {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -723,7 +912,7 @@ extension HomeViewModel {
             extraParameters: [.advertisementId: "\(advertisement.adId)"]
         ))
     }
-    
+
     private func sendClickAdMarker(advertisement: AdvertisementResponse) {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -732,7 +921,7 @@ extension HomeViewModel {
             extraParameters: [.advertisementId: "\(advertisement.advertisementId)"]
         ))
     }
-    
+
     private func sendClickRecentActivityFilter(isOn: Bool) {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -741,7 +930,7 @@ extension HomeViewModel {
             extraParameters: [.value: isOn]
         ))
     }
-    
+
     private func sendClickMarkerLog() {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -749,7 +938,7 @@ extension HomeViewModel {
             objectId: .store
         ))
     }
-    
+
     private func sendClickFeedButtonLog() {
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
@@ -763,23 +952,19 @@ extension HomeViewModel: HomeFilterSelectable {
     var onTapCategoryFilter: PassthroughSubject<Void, Never> {
         input.onTapCategoryFilter
     }
-    
-    var onTapOnlyRecentActivity: PassthroughSubject<Void, Never> {
-        input.onTapOnlyRecentActivity
+
+    var onTapRadioOption: PassthroughSubject<(paramKey: String, optionIndex: Int), Never> {
+        input.onTapRadioOption
     }
-    
-    var onToggleSort: PassthroughSubject<Model.StoreSortType, Never> {
-        input.onToggleSort
+
+    var onTapActionLink: PassthroughSubject<SDLink, Never> {
+        input.onTapActionLink
     }
-    
-    var onTapOnlyBoss: PassthroughSubject<Void, Never> {
-        input.onTapOnlyBoss
-    }
-    
+
     var selectCategory: PassthroughSubject<StoreFoodCategoryResponse?, Never> {
         input.selectCategory
     }
-    
+
     var filterDatasource: CurrentValueSubject<[HomeFilterCollectionView.CellType], Never> {
         output.filterDatasource
     }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -763,7 +763,7 @@ extension HomeViewModel {
 
     private func sendClickFilterLog(option: HomeFilterRadioOption) {
         guard let clickLog = option.clickLog else { return }
-        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+        dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
     }
 
     private func sendActionBarClickLog(for link: SDLink) {
@@ -771,7 +771,7 @@ extension HomeViewModel {
             .compactMap { $0 as? HomeFilterActionBar }
             .first { $0.button.link == link }
         guard let clickLog = actionBar?.clickLog else { return }
-        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+        dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
     }
 
     private func sendCurrentCategoryCloseLog() {
@@ -780,7 +780,7 @@ extension HomeViewModel {
             .first?
             .currentCategoryFilter
         guard let clickLog = currentCategory?.clickLog else { return }
-        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+        dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
     }
 
     private func applyParamValueToLegacyState(paramKey: String, paramValue: String?) {
@@ -918,7 +918,7 @@ extension HomeViewModel {
             .compactMap({ $0 as? HomeFilterCategoryBar })
             .first?
             .categoriesFilterClickLog {
-            dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+            dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
             return
         }
         dependency.logManager.sendEvent(event: ClickEvent(

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -831,7 +831,7 @@ extension HomeViewModel {
         for bar in allBars {
             switch bar {
             case let categoryBar as HomeFilterCategoryBar:
-                cells.append(.chip(categoryBar.categoriesFilter, surface: nil, action: .openCategoryFilter))
+                cells.append(.chip(categoryBar.categoriesFilter, action: .openCategoryFilter))
                 if let category = state.categoryFilter {
                     let fontColor = categoryBar.currentCategoryFilter?.fontColor ?? "#000000"
                     let chip = makeSelectedCategoryChip(category: category, fontColor: fontColor)
@@ -842,9 +842,8 @@ extension HomeViewModel {
                 guard radioBar.options.isEmpty.isNot,
                       let currentOption = radioBar.options[safe: selectedIndex] else { break }
                 let nextIndex = (selectedIndex + 1) % radioBar.options.count
-                let surface: SDSurfaceStyle? = selectedIndex == 0 ? nil : selectedSurface(for: currentOption.chip)
                 let action = HomeFilterCollectionView.ChipAction.selectRadio(paramKey: radioBar.paramKey, optionIndex: nextIndex)
-                cells.append(.chip(currentOption.chip, surface: surface, action: action))
+                cells.append(.chip(currentOption.chip, action: action))
             case let actionBar as HomeFilterActionBar:
                 cells.append(.button(actionBar.button, surface: nil))
             default:
@@ -852,16 +851,6 @@ extension HomeViewModel {
             }
         }
         return cells
-    }
-
-    private func selectedSurface(for chip: SDChip) -> SDSurfaceStyle? {
-        guard let background = chip.style?.backgroundColor else { return nil }
-        return SDSurfaceStyle(
-            backgroundColor: background,
-            borderColor: chip.text.fontColor,
-            borderWidth: 1,
-            cornerRadius: 10
-        )
     }
 
     private func makeSelectedCategoryChip(category: StoreFoodCategoryResponse, fontColor: String) -> SDChip {
@@ -879,7 +868,7 @@ extension HomeViewModel {
             style: nil
         )
         var cells: [HomeFilterCollectionView.CellType] = [
-            .chip(categoriesChip, surface: nil, action: .openCategoryFilter)
+            .chip(categoriesChip, action: .openCategoryFilter)
         ]
         if let category = state.categoryFilter {
             let chip = makeSelectedCategoryChip(category: category, fontColor: "#000000")

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCell.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCell.swift
@@ -1,128 +1,183 @@
 import UIKit
 
 import Common
+import DesignSystem
 import Model
 
 import Kingfisher
+import SnapKit
 
 final class HomeFilterCell: BaseCollectionViewCell {
     enum Layout {
-        static let iconSize = CGSize(width: 18, height: 18)
-        static let leadingMargin: CGFloat = 8
-        static let stackViewSpacing: CGFloat = 2
+        static let leadingMargin: CGFloat = 10
+        static let stackViewSpacing: CGFloat = 6
         static let trailingMargin: CGFloat = 10
-        static func size(title: String?) -> CGSize {
-            guard let title = title else { return .zero }
-            let stringWidth = NSString(string: title).size().width
-            let width = leadingMargin + iconSize.width + stackViewSpacing + stringWidth + trailingMargin
-            return CGSize(width: width, height: 34)
+        static let height: CGFloat = 34
+        static let labelHeight: CGFloat = 18
+        static let defaultIconSize: CGFloat = 20
+        static let closeButtonSize: CGFloat = 14
+
+        static func size(for chip: SDChip) -> CGSize {
+            sizingCell.bind(chip: chip, surface: nil)
+            return measureSizingCell()
+        }
+
+        static func size(for button: SDButton) -> CGSize {
+            sizingCell.bind(button: button, surface: nil)
+            return measureSizingCell()
+        }
+
+        static func sizeForSelectedCategory(chip: SDChip) -> CGSize {
+            sizingCell.bindSelectedCategory(chip: chip, onClose: {})
+            return measureSizingCell()
+        }
+
+        private static let sizingCell = HomeFilterCell()
+
+        private static func measureSizingCell() -> CGSize {
+            sizingCell.setNeedsLayout()
+            sizingCell.layoutIfNeeded()
+            let fittingSize = sizingCell.contentView.systemLayoutSizeFitting(
+                CGSize(width: CGFloat.greatestFiniteMagnitude, height: height),
+                withHorizontalFittingPriority: .fittingSizeLevel,
+                verticalFittingPriority: .required
+            )
+            return CGSize(width: ceil(fittingSize.width), height: height)
         }
     }
-    
-    private let containerView = UIView()
-    
+
     private let stackView: UIStackView = {
         let stackView = UIStackView()
-        stackView.spacing = 2
+        stackView.spacing = Layout.stackViewSpacing
         stackView.axis = .horizontal
+        stackView.alignment = .center
         return stackView
     }()
-    
-    private let iconImage: UIImageView = {
+
+    private let iconImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = Icons.category.image
-            .resizeImage(scaledTo: 16)
-            .withTintColor(Colors.gray70.color)
+        imageView.contentMode = .scaleAspectFit
         return imageView
     }()
-    
+
     private let titleLabel: UILabel = {
-        let titleLabel = UILabel()
-        titleLabel.font = Fonts.medium.font(size: 12)
-        titleLabel.textColor = Colors.gray70.color
-        titleLabel.text = HomeStrings.homeCategoryFilterButton
-        return titleLabel
+        let label = UILabel()
+        label.font = Fonts.medium.font(size: 12)
+        label.textColor = Colors.gray70.color
+        return label
     }()
-    
+
+    private let closeButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(Icons.close.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.isHidden = true
+        return button
+    }()
+
+    private var iconWidthConstraint: Constraint?
+    private var iconHeightConstraint: Constraint?
+    private var onClose: (() -> Void)?
+
     override func prepareForReuse() {
         super.prepareForReuse()
-        
-        setSelected(false)
+
+        iconImageView.kf.cancelDownloadTask()
+        iconImageView.image = nil
+        iconImageView.isHidden = false
+        titleLabel.text = nil
+        titleLabel.attributedText = nil
+        layer.borderColor = nil
+        layer.borderWidth = 0
+        layer.cornerRadius = 10
+        backgroundColor = nil
+        closeButton.isHidden = true
+        onClose = nil
     }
-    
+
     override func setup() {
-        layer.borderColor = Colors.gray30.color.cgColor
-        layer.borderWidth = 1
         layer.cornerRadius = 10
         layer.masksToBounds = true
-        clipsToBounds = true
-        backgroundColor = Colors.systemWhite.color
-        
-        stackView.addArrangedSubview(iconImage)
-        iconImage.snp.makeConstraints {
-            $0.size.equalTo(18)
-        }
+
+        stackView.addArrangedSubview(iconImageView)
         stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(closeButton)
+
+        iconImageView.snp.makeConstraints {
+            iconWidthConstraint = $0.width.equalTo(Layout.defaultIconSize).constraint
+            iconHeightConstraint = $0.height.equalTo(Layout.defaultIconSize).constraint
+        }
+
         titleLabel.snp.makeConstraints {
-            $0.height.equalTo(18)
+            $0.height.equalTo(Layout.labelHeight)
         }
-        
-        containerView.addSubview(stackView)
+
+        closeButton.snp.makeConstraints {
+            $0.size.equalTo(Layout.closeButtonSize)
+        }
+
+        closeButton.addAction(UIAction { [weak self] _ in
+            self?.onClose?()
+        }, for: .touchUpInside)
+
+        contentView.addSubview(stackView)
         stackView.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(8)
-            $0.top.equalToSuperview().offset(8)
-            $0.height.equalTo(18)
-        }
-        
-        contentView.addSubview(containerView)
-        containerView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.leading.equalToSuperview().offset(Layout.leadingMargin)
+            $0.trailing.equalToSuperview().offset(-Layout.trailingMargin)
+            $0.centerY.equalToSuperview()
         }
     }
-    
-    func bind(category: StoreFoodCategoryResponse?) {
-        if let category = category,
-           let categoryUrl = URL(string: category.imageUrl) {
-            KingfisherManager.shared.retrieveImage(with: categoryUrl) { [weak self] result in
-                switch result {
-                case .success(let imageResult):
-                    let image = imageResult.image
-                        .resizeImage(scaledTo: 16)
-                        .withImageInset(insets: .init(top: 2, left: 2, bottom: 2, right: 2))
-                    self?.iconImage.image = image
-                case .failure(_):
-                    self?.iconImage.image = nil
-                }
-            }
-            titleLabel.text = category.name
-            titleLabel.textColor = Colors.mainPink.color
-            backgroundColor = Colors.gray100.color
-        } else {
-            iconImage.image = Icons.category.image
-                .resizeImage(scaledTo: 16)
-                .withImageInset(insets: .init(top: 2, left: 2, bottom: 2, right: 2))
-                .withTintColor(Colors.gray70.color)
-            titleLabel.text = HomeStrings.homeCategoryFilterButton
-            titleLabel.textColor = Colors.gray70.color
-            backgroundColor = Colors.systemWhite.color
+
+    func bind(chip: SDChip, surface: SDSurfaceStyle?) {
+        closeButton.isHidden = true
+        applyImage(chip.image)
+        titleLabel.setSDText(chip.text)
+        applyBackground(surface: surface, fallbackHex: chip.style?.backgroundColor)
+    }
+
+    func bind(button: SDButton, surface: SDSurfaceStyle?) {
+        closeButton.isHidden = true
+        applyImage(button.image)
+        titleLabel.setSDText(button.text)
+        applyBackground(surface: surface, fallbackHex: button.style.backgroundColor)
+    }
+
+    func bindSelectedCategory(chip: SDChip, onClose: @escaping () -> Void) {
+        applyImage(chip.image)
+        titleLabel.setSDText(chip.text)
+        titleLabel.textColor = Colors.pink500.color
+
+        backgroundColor = Colors.pink100.color
+        layer.borderColor = Colors.pink500.color.cgColor
+        layer.borderWidth = 1
+        layer.cornerRadius = 10
+
+        closeButton.isHidden = false
+        closeButton.tintColor = Colors.pink500.color
+        self.onClose = onClose
+    }
+
+    private func applyImage(_ image: SDImage?) {
+        guard let image, let url = URL(string: image.url) else {
+            iconImageView.isHidden = true
+            iconWidthConstraint?.update(offset: 0)
+            iconHeightConstraint?.update(offset: 0)
+            return
         }
+        iconImageView.isHidden = false
+        iconWidthConstraint?.update(offset: image.style.width)
+        iconHeightConstraint?.update(offset: image.style.height)
+        iconImageView.kf.setImage(with: url)
     }
-    
-    func bind(icon: UIImage?, title: String?, isSelected: Bool = false) {
-        iconImage.image = icon
-        titleLabel.text = title
-        setSelected(isSelected)
-    }
-    
-    private func setSelected(_ isSelected: Bool) {
-        if isSelected {
-            backgroundColor = Colors.pink100.color
-            layer.borderColor = Colors.mainPink.color.cgColor
-            titleLabel.textColor = Colors.mainPink.color
+
+    private func applyBackground(surface: SDSurfaceStyle?, fallbackHex: String?) {
+        if let surface {
+            setSDSurfaceStyle(surface)
+        } else if let fallbackHex, let color = UIColor(hex: fallbackHex) {
+            backgroundColor = color
         } else {
             backgroundColor = Colors.systemWhite.color
             layer.borderColor = Colors.gray30.color.cgColor
-            titleLabel.textColor = Colors.gray70.color
+            layer.borderWidth = 1
         }
     }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCell.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCell.swift
@@ -18,7 +18,7 @@ final class HomeFilterCell: BaseCollectionViewCell {
         static let closeButtonSize: CGFloat = 14
 
         static func size(for chip: SDChip) -> CGSize {
-            sizingCell.bind(chip: chip, surface: nil)
+            sizingCell.bind(chip: chip)
             return measureSizingCell()
         }
 
@@ -127,15 +127,18 @@ final class HomeFilterCell: BaseCollectionViewCell {
         }
     }
 
-    func bind(chip: SDChip, surface: SDSurfaceStyle?) {
+    func bind(chip: SDChip) {
         closeButton.isHidden = true
         applyImage(chip.image)
         titleLabel.setSDText(chip.text)
-        applyBackground(
-            surface: surface,
-            fallbackHex: chip.style?.backgroundColor,
-            fallbackBorder: chip.style?.border
-        )
+
+        if let style = chip.style {
+            backgroundColor = UIColor(hex: style.backgroundColor)
+            if let border = style.border {
+                layer.borderColor = UIColor(hex: border.color)?.cgColor
+                layer.borderWidth = border.width
+            }
+        }
     }
 
     func bind(button: SDButton, surface: SDSurfaceStyle?) {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCell.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCell.swift
@@ -27,8 +27,8 @@ final class HomeFilterCell: BaseCollectionViewCell {
             return measureSizingCell()
         }
 
-        static func sizeForSelectedCategory(chip: SDChip) -> CGSize {
-            sizingCell.bindSelectedCategory(chip: chip, onClose: {})
+        static func sizeForSelectedCategory(chip: SDChip, current: HomeFilterCurrentCategory?) -> CGSize {
+            sizingCell.bindSelectedCategory(chip: chip, current: current, onClose: {})
             return measureSizingCell()
         }
 
@@ -131,28 +131,45 @@ final class HomeFilterCell: BaseCollectionViewCell {
         closeButton.isHidden = true
         applyImage(chip.image)
         titleLabel.setSDText(chip.text)
-        applyBackground(surface: surface, fallbackHex: chip.style?.backgroundColor)
+        applyBackground(
+            surface: surface,
+            fallbackHex: chip.style?.backgroundColor,
+            fallbackBorder: chip.style?.border
+        )
     }
 
     func bind(button: SDButton, surface: SDSurfaceStyle?) {
         closeButton.isHidden = true
         applyImage(button.image)
         titleLabel.setSDText(button.text)
-        applyBackground(surface: surface, fallbackHex: button.style.backgroundColor)
+        applyBackground(
+            surface: surface,
+            fallbackHex: button.style.backgroundColor,
+            fallbackBorder: button.style.border
+        )
     }
 
-    func bindSelectedCategory(chip: SDChip, onClose: @escaping () -> Void) {
+    /// `current` 가 있으면 서버가 내려준 fontColor/style 을 그대로 적용. nil 이면 SDU 미지원 fallback (분홍 pill).
+    func bindSelectedCategory(chip: SDChip, current: HomeFilterCurrentCategory?, onClose: @escaping () -> Void) {
         applyImage(chip.image)
         titleLabel.setSDText(chip.text)
-        titleLabel.textColor = Colors.pink500.color
 
-        backgroundColor = Colors.pink100.color
-        layer.borderColor = Colors.pink500.color.cgColor
-        layer.borderWidth = 1
-        layer.cornerRadius = 10
+        if let current {
+            if let fontColor = UIColor(hex: current.fontColor) {
+                titleLabel.textColor = fontColor
+                closeButton.tintColor = fontColor
+            }
+            setSDSurfaceStyle(current.style)
+        } else {
+            titleLabel.textColor = Colors.pink500.color
+            backgroundColor = Colors.pink100.color
+            layer.borderColor = Colors.pink500.color.cgColor
+            layer.borderWidth = 1
+            layer.cornerRadius = 10
+            closeButton.tintColor = Colors.pink500.color
+        }
 
         closeButton.isHidden = false
-        closeButton.tintColor = Colors.pink500.color
         self.onClose = onClose
     }
 
@@ -169,15 +186,21 @@ final class HomeFilterCell: BaseCollectionViewCell {
         iconImageView.kf.setImage(with: url)
     }
 
-    private func applyBackground(surface: SDSurfaceStyle?, fallbackHex: String?) {
+    private func applyBackground(surface: SDSurfaceStyle?, fallbackHex: String?, fallbackBorder: SDBorder?) {
         if let surface {
             setSDSurfaceStyle(surface)
-        } else if let fallbackHex, let color = UIColor(hex: fallbackHex) {
-            backgroundColor = color
-        } else {
-            backgroundColor = Colors.systemWhite.color
-            layer.borderColor = Colors.gray30.color.cgColor
-            layer.borderWidth = 1
+            return
         }
+        if let fallbackHex, let color = UIColor(hex: fallbackHex) {
+            backgroundColor = color
+            if let fallbackBorder, let borderColor = UIColor(hex: fallbackBorder.color) {
+                layer.borderColor = borderColor.cgColor
+                layer.borderWidth = fallbackBorder.width
+            }
+            return
+        }
+        backgroundColor = Colors.systemWhite.color
+        layer.borderColor = Colors.gray30.color.cgColor
+        layer.borderWidth = 1
     }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCollectionView.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCollectionView.swift
@@ -17,7 +17,7 @@ extension HomeFilterCollectionView {
     }
 
     enum CellType: Hashable {
-        case chip(SDChip, surface: SDSurfaceStyle?, action: ChipAction)
+        case chip(SDChip, action: ChipAction)
         case button(SDButton, surface: SDSurfaceStyle?)
         case selectedCategoryChip(SDChip, current: HomeFilterCurrentCategory?)
     }
@@ -39,7 +39,7 @@ final class HomeFilterCollectionView: UICollectionView {
     /// 첫 RADIO_BAR 칩의 IndexPath (없으면 nil). HomeView 의 tooltip 위치 계산용.
     var firstRadioCellIndexPath: IndexPath? {
         guard let index = datasource.firstIndex(where: { cell in
-            if case .chip(_, _, .selectRadio) = cell { return true }
+            if case .chip(_, .selectRadio) = cell { return true }
             return false
         }) else { return nil }
         return IndexPath(item: index, section: 0)
@@ -96,9 +96,9 @@ extension HomeFilterCollectionView: UICollectionViewDataSource {
         guard let item = datasource[safe: indexPath.item] else { return BaseCollectionViewCell() }
 
         switch item {
-        case .chip(let chip, let surface, _):
+        case .chip(let chip, _):
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
-            cell.bind(chip: chip, surface: surface)
+            cell.bind(chip: chip)
             return cell
         case .button(let button, let surface):
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
@@ -119,7 +119,7 @@ extension HomeFilterCollectionView: UICollectionViewDelegateFlowLayout {
         guard let item = datasource[safe: indexPath.item] else { return .zero }
 
         switch item {
-        case .chip(let chip, _, _):
+        case .chip(let chip, _):
             return HomeFilterCell.Layout.size(for: chip)
         case .button(let button, _):
             return HomeFilterCell.Layout.size(for: button)
@@ -132,7 +132,7 @@ extension HomeFilterCollectionView: UICollectionViewDelegateFlowLayout {
         guard let item = datasource[safe: indexPath.item] else { return }
 
         switch item {
-        case .chip(_, _, let action):
+        case .chip(_, let action):
             handleAction(action)
         case .button(let button, _):
             if let link = button.link {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCollectionView.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCollectionView.swift
@@ -19,7 +19,7 @@ extension HomeFilterCollectionView {
     enum CellType: Hashable {
         case chip(SDChip, surface: SDSurfaceStyle?, action: ChipAction)
         case button(SDButton, surface: SDSurfaceStyle?)
-        case selectedCategoryChip(SDChip)
+        case selectedCategoryChip(SDChip, current: HomeFilterCurrentCategory?)
     }
 
     enum ChipAction: Hashable {
@@ -104,10 +104,10 @@ extension HomeFilterCollectionView: UICollectionViewDataSource {
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
             cell.bind(button: button, surface: surface)
             return cell
-        case .selectedCategoryChip(let chip):
+        case .selectedCategoryChip(let chip, let current):
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
-            cell.bindSelectedCategory(chip: chip) { [weak self] in
-                self?.homeFilterSelectable.selectCategory.send(nil)
+            cell.bindSelectedCategory(chip: chip, current: current) { [weak self] in
+                self?.homeFilterSelectable.onTapCloseSelectedCategory.send(())
             }
             return cell
         }
@@ -123,8 +123,8 @@ extension HomeFilterCollectionView: UICollectionViewDelegateFlowLayout {
             return HomeFilterCell.Layout.size(for: chip)
         case .button(let button, _):
             return HomeFilterCell.Layout.size(for: button)
-        case .selectedCategoryChip(let chip):
-            return HomeFilterCell.Layout.sizeForSelectedCategory(chip: chip)
+        case .selectedCategoryChip(let chip, let current):
+            return HomeFilterCell.Layout.sizeForSelectedCategory(chip: chip, current: current)
         }
     }
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCollectionView.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterCollectionView.swift
@@ -7,7 +7,7 @@ import Model
 extension HomeFilterCollectionView {
     enum Layout {
         static let interItemSpacing: CGFloat = 10
-        
+
         static func createLayout() -> UICollectionViewFlowLayout {
             let layout = UICollectionViewFlowLayout()
             layout.minimumInteritemSpacing = Layout.interItemSpacing
@@ -15,47 +15,17 @@ extension HomeFilterCollectionView {
             return layout
         }
     }
-    
-    enum CellType {
-        case category(StoreFoodCategoryResponse?)
-        case recentActivity(Bool)
-        case sortingFilter(StoreSortType)
-        case onlyBoss(Bool)
-        
-        var icon: UIImage? {
-            switch self {
-            case .category:
-                return nil
-            case .sortingFilter:
-                return Icons.change.image
-                    .resizeImage(scaledTo: 16)
-                    .withImageInset(insets: .init(top: 2, left: 2, bottom: 2, right: 2))
-            case .recentActivity:
-                return "🔥".image()?.withImageInset(insets: .init(top: 3, left: 3, bottom: 3, right: 3))
-            case .onlyBoss:
-                return "🧑‍🍳".image()?.withImageInset(insets: .init(top: 3, left: 3, bottom: 3, right: 3))
-            }
-        }
-        
-        var title: String? {
-            switch self {
-            case .category:
-                return nil
-            case .recentActivity:
-                return HomeStrings.homeRecentActivity
-            case .sortingFilter(let sortType):
-                switch sortType {
-                case .distanceAsc:
-                    return HomeStrings.homeSortingButtonDistance
-                case .latest:
-                    return HomeStrings.homeSortingButtonLatest
-                case .unknown:
-                    return nil
-                }
-            case .onlyBoss:
-                return HomeStrings.homeOnlyBossButton
-            }
-        }
+
+    enum CellType: Hashable {
+        case chip(SDChip, surface: SDSurfaceStyle?, action: ChipAction)
+        case button(SDButton, surface: SDSurfaceStyle?)
+        case selectedCategoryChip(SDChip)
+    }
+
+    enum ChipAction: Hashable {
+        case openCategoryFilter
+        case selectRadio(paramKey: String, optionIndex: Int)
+        case openLink(SDLink)
     }
 }
 
@@ -65,38 +35,47 @@ final class HomeFilterCollectionView: UICollectionView {
     private let homeFilterSelectable: HomeFilterSelectable
     private var cancellables = Set<AnyCancellable>()
     private var isFirstLoad = true
-    
+
+    /// 첫 RADIO_BAR 칩의 IndexPath (없으면 nil). HomeView 의 tooltip 위치 계산용.
+    var firstRadioCellIndexPath: IndexPath? {
+        guard let index = datasource.firstIndex(where: { cell in
+            if case .chip(_, _, .selectRadio) = cell { return true }
+            return false
+        }) else { return nil }
+        return IndexPath(item: index, section: 0)
+    }
+
     init(homeFilterSelectable: HomeFilterSelectable) {
         self.homeFilterSelectable = homeFilterSelectable
         super.init(frame: .zero, collectionViewLayout: Layout.createLayout())
-        
+
         setup()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func setup() {
         backgroundColor = .clear
         register([
             HomeFilterCell.self,
             BaseCollectionViewCell.self
         ])
-        
+
         showsHorizontalScrollIndicator = false
         contentInset = .init(top: 13, left: 22, bottom: 13, right: 22)
-        
+
         delegate = self
         dataSource = self
-        
+
         homeFilterSelectable.filterDatasource
             .main
             .withUnretained(self)
             .sink { (owner: HomeFilterCollectionView, datasource: [CellType]) in
                 owner.datasource = datasource
                 owner.reloadData()
-                
+
                 if owner.isFirstLoad {
                     owner.isFirstLoad = false
                     DispatchQueue.main.async {
@@ -112,26 +91,24 @@ extension HomeFilterCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return datasource.count
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let item = datasource[safe: indexPath.item] else { return BaseCollectionViewCell() }
-        
+
         switch item {
-        case .category(let category):
+        case .chip(let chip, let surface, _):
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
-            cell.bind(category: category)
+            cell.bind(chip: chip, surface: surface)
             return cell
-        case .recentActivity(let isOn):
+        case .button(let button, let surface):
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
-            cell.bind(icon: item.icon, title: item.title, isSelected: isOn)
+            cell.bind(button: button, surface: surface)
             return cell
-        case .sortingFilter:
+        case .selectedCategoryChip(let chip):
             let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
-            cell.bind(icon: item.icon, title: item.title)
-            return cell
-        case .onlyBoss(let isOn):
-            let cell: HomeFilterCell = collectionView.dequeueReusableCell(indexPath: indexPath)
-            cell.bind(icon: item.icon, title: item.title, isSelected: isOn)
+            cell.bindSelectedCategory(chip: chip) { [weak self] in
+                self?.homeFilterSelectable.selectCategory.send(nil)
+            }
             return cell
         }
     }
@@ -140,36 +117,40 @@ extension HomeFilterCollectionView: UICollectionViewDataSource {
 extension HomeFilterCollectionView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard let item = datasource[safe: indexPath.item] else { return .zero }
-        
+
         switch item {
-        case .category(let category):
-            return HomeFilterCell.Layout.size(title: category?.name ?? HomeStrings.homeCategoryFilterButton)
-        case .recentActivity, .onlyBoss, .sortingFilter:
-            return HomeFilterCell.Layout.size(title: item.title)
+        case .chip(let chip, _, _):
+            return HomeFilterCell.Layout.size(for: chip)
+        case .button(let button, _):
+            return HomeFilterCell.Layout.size(for: button)
+        case .selectedCategoryChip(let chip):
+            return HomeFilterCell.Layout.sizeForSelectedCategory(chip: chip)
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let item = datasource[safe: indexPath.item] else { return }
-        
+
         switch item {
-        case .category:
-            homeFilterSelectable.onTapCategoryFilter.send(())
-        case .recentActivity:
-            homeFilterSelectable.onTapOnlyRecentActivity.send(())
-        case .sortingFilter(let sortType):
-            homeFilterSelectable.onToggleSort.send(sortType)
-        case .onlyBoss:
-            homeFilterSelectable.onTapOnlyBoss.send(())
+        case .chip(_, _, let action):
+            handleAction(action)
+        case .button(let button, _):
+            if let link = button.link {
+                homeFilterSelectable.onTapActionLink.send(link)
+            }
+        case .selectedCategoryChip:
+            break
         }
     }
-}
 
-private extension String {
-    func image(withAttributes attributes: [NSAttributedString.Key: Any]? = nil, size: CGSize? = nil) -> UIImage? {
-        let size = size ?? (self as NSString).size(withAttributes: attributes)
-        return UIGraphicsImageRenderer(size: size).image { _ in
-            (self as NSString).draw(in: CGRect(origin: .zero, size: size),withAttributes: attributes)
+    private func handleAction(_ action: ChipAction) {
+        switch action {
+        case .openCategoryFilter:
+            homeFilterSelectable.onTapCategoryFilter.send(())
+        case .selectRadio(let paramKey, let optionIndex):
+            homeFilterSelectable.onTapRadioOption.send((paramKey, optionIndex))
+        case .openLink(let link):
+            homeFilterSelectable.onTapActionLink.send(link)
         }
     }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterSelectable.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterSelectable.swift
@@ -7,6 +7,7 @@ protocol HomeFilterSelectable {
     var onTapCategoryFilter: PassthroughSubject<Void, Never> { get }
     var onTapRadioOption: PassthroughSubject<(paramKey: String, optionIndex: Int), Never> { get }
     var onTapActionLink: PassthroughSubject<SDLink, Never> { get }
+    var onTapCloseSelectedCategory: PassthroughSubject<Void, Never> { get }
     var selectCategory: PassthroughSubject<StoreFoodCategoryResponse?, Never> { get }
 
     // Output

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterSelectable.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/Subview/HomeFilterCollectionView/HomeFilterSelectable.swift
@@ -5,11 +5,10 @@ import Model
 protocol HomeFilterSelectable {
     // Input
     var onTapCategoryFilter: PassthroughSubject<Void, Never> { get }
-    var onTapOnlyRecentActivity: PassthroughSubject<Void, Never> { get }
-    var onToggleSort: PassthroughSubject<StoreSortType, Never> { get }
-    var onTapOnlyBoss: PassthroughSubject<Void, Never> { get }
+    var onTapRadioOption: PassthroughSubject<(paramKey: String, optionIndex: Int), Never> { get }
+    var onTapActionLink: PassthroughSubject<SDLink, Never> { get }
     var selectCategory: PassthroughSubject<StoreFoodCategoryResponse?, Never> { get }
-    
+
     // Output
     var filterDatasource: CurrentValueSubject<[HomeFilterCollectionView.CellType], Never> { get }
 }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListDataSource.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListDataSource.swift
@@ -78,22 +78,19 @@ final class HomeListDataSource: UICollectionViewDiffableDataSource<HomeListSecti
                 }
                 .store(in: &headerView.cancellables)
             
-            viewModel.output.filterDatasource
+            viewModel.output.categoryFilter
                 .receive(on: DispatchQueue.main)
                 .withUnretained(headerView)
-                .sink { (headerView: HomeListHeaderCell, cellTypeList: [HomeFilterCollectionView.CellType]) in
-                    for cellType in cellTypeList {
-                        switch cellType {
-                        case .category(let category):
-                            headerView.bind(category: category)
-                        case .recentActivity:
-                            continue
-                        case .sortingFilter:
-                            continue
-                        case .onlyBoss(let isOnlyBoss):
-                            headerView.isOnlyCertifiedButton.isHidden = isOnlyBoss
-                        }
-                    }
+                .sink { (headerView: HomeListHeaderCell, category: StoreFoodCategoryResponse?) in
+                    headerView.bind(category: category)
+                }
+                .store(in: &headerView.cancellables)
+
+            viewModel.output.isOnlyBoss
+                .receive(on: DispatchQueue.main)
+                .withUnretained(headerView)
+                .sink { (headerView: HomeListHeaderCell, isOnlyBoss: Bool) in
+                    headerView.isOnlyCertifiedButton.isHidden = isOnlyBoss
                 }
                 .store(in: &headerView.cancellables)
             return headerView

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -361,7 +361,7 @@ final class HomeListViewModel: BaseViewModel {
         for bar in allBars {
             switch bar {
             case let categoryBar as HomeFilterCategoryBar:
-                cells.append(.chip(categoryBar.categoriesFilter, surface: nil, action: .openCategoryFilter))
+                cells.append(.chip(categoryBar.categoriesFilter, action: .openCategoryFilter))
                 if let category = categoryFilter {
                     let fontColor = categoryBar.currentCategoryFilter?.fontColor ?? "#000000"
                     let chip = makeSelectedCategoryChip(category: category, fontColor: fontColor)
@@ -372,9 +372,8 @@ final class HomeListViewModel: BaseViewModel {
                 guard radioBar.options.isEmpty.isNot,
                       let currentOption = radioBar.options[safe: selectedIndex] else { break }
                 let nextIndex = (selectedIndex + 1) % radioBar.options.count
-                let surface: SDSurfaceStyle? = selectedIndex == 0 ? nil : selectedSurface(for: currentOption.chip)
                 let action = HomeFilterCollectionView.ChipAction.selectRadio(paramKey: radioBar.paramKey, optionIndex: nextIndex)
-                cells.append(.chip(currentOption.chip, surface: surface, action: action))
+                cells.append(.chip(currentOption.chip, action: action))
             case let actionBar as HomeFilterActionBar:
                 cells.append(.button(actionBar.button, surface: nil))
             default:
@@ -399,11 +398,11 @@ final class HomeListViewModel: BaseViewModel {
             style: nil
         )
         var cells: [HomeFilterCollectionView.CellType] = [
-            .chip(categoriesChip, surface: nil, action: .openCategoryFilter)
+            .chip(categoriesChip, action: .openCategoryFilter)
         ]
         if let categoryFilter {
             let chip = makeSelectedCategoryChip(category: categoryFilter, fontColor: "#FF858F")
-            cells.append(.chip(chip, surface: nil, action: .openCategoryFilter))
+            cells.append(.chip(chip, action: .openCategoryFilter))
         }
         // optionIndex 는 "탭 후 전환될 다음 인덱스" 를 의미 (SDU chip 과 동일 규약).
         let recentActivityChip = SDChip(
@@ -413,7 +412,6 @@ final class HomeListViewModel: BaseViewModel {
         )
         cells.append(.chip(
             recentActivityChip,
-            surface: nil,
             action: .selectRadio(paramKey: "filterConditions", optionIndex: isOnlyRecentActivity ? 0 : 1)
         ))
         let sortChip = SDChip(
@@ -423,7 +421,6 @@ final class HomeListViewModel: BaseViewModel {
         )
         cells.append(.chip(
             sortChip,
-            surface: nil,
             action: .selectRadio(paramKey: "sortType", optionIndex: isLatestSort ? 0 : 1)
         ))
         let bossChip = SDChip(
@@ -433,20 +430,9 @@ final class HomeListViewModel: BaseViewModel {
         )
         cells.append(.chip(
             bossChip,
-            surface: nil,
             action: .selectRadio(paramKey: "targetStores", optionIndex: isOnlyBossStore ? 0 : 1)
         ))
         return cells
-    }
-
-    private static func selectedSurface(for chip: SDChip) -> SDSurfaceStyle? {
-        guard let background = chip.style?.backgroundColor else { return nil }
-        return SDSurfaceStyle(
-            backgroundColor: background,
-            borderColor: chip.text.fontColor,
-            borderWidth: 1,
-            cornerRadius: 10
-        )
     }
 
     private static func makeSelectedCategoryChip(category: StoreFoodCategoryResponse, fontColor: String) -> SDChip {

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -284,7 +284,7 @@ final class HomeListViewModel: BaseViewModel {
             .first(where: { $0.paramKey == paramKey }),
               let option = radioBar.options[safe: optionIndex],
               let clickLog = option.clickLog else { return }
-        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+        dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
     }
 
     private func sendActionBarClickLog(for link: SDLink) {
@@ -292,7 +292,7 @@ final class HomeListViewModel: BaseViewModel {
             .compactMap { $0 as? HomeFilterActionBar }
             .first { $0.button.link == link }
         guard let clickLog = actionBar?.clickLog else { return }
-        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+        dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
     }
 
     private func sendCurrentCategoryCloseLog() {
@@ -301,7 +301,7 @@ final class HomeListViewModel: BaseViewModel {
             .first?
             .currentCategoryFilter
         guard let clickLog = currentCategory?.clickLog else { return }
-        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+        dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
     }
 
     /// SDU 응답에서 paramValue 를 우선 조회. 응답이 없으면 fallback chip 의 optionIndex(0/1) 로 추정한다.
@@ -599,7 +599,7 @@ extension HomeListViewModel {
             .compactMap({ $0 as? HomeFilterCategoryBar })
             .first?
             .categoriesFilterClickLog {
-            dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+            dependency.logManager.sendEvent(event: ClickEvent(clickLog: clickLog))
             return
         }
         dependency.logManager.sendEvent(event: ClickEvent(

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -14,6 +14,8 @@ extension HomeListViewModel {
         let viewDidLoad = PassthroughSubject<Void, Never>()
         let willDisplay = PassthroughSubject<Int, Never>()
         let onTapCategoryFilter = PassthroughSubject<Void, Never>()
+        let onTapRadioOption = PassthroughSubject<(paramKey: String, optionIndex: Int), Never>()
+        let onTapActionLink = PassthroughSubject<SDLink, Never>()
         let onTapOnlyRecentActivity = PassthroughSubject<Void, Never>()
         let selectCategory = PassthroughSubject<StoreFoodCategoryResponse?, Never>()
         let onToggleSort = PassthroughSubject<StoreSortType, Never>()
@@ -22,21 +24,23 @@ extension HomeListViewModel {
         let onTapStore = PassthroughSubject<StoreWithExtraResponse, Never>()
         let onTapAdvertisement = PassthroughSubject<AdvertisementResponse?, Never>()
     }
-    
+
     struct Output {
         let screenName: ScreenName = .homeList
         let dataSource = CurrentValueSubject<[HomeListSection], Never>([])
         let filterDatasource: CurrentValueSubject<[HomeFilterCollectionView.CellType], Never>
+        let categoryFilter: CurrentValueSubject<StoreFoodCategoryResponse?, Never>
+        let isOnlyBoss: CurrentValueSubject<Bool, Never>
         let isOnlyCertified = CurrentValueSubject<Bool, Never>(false)
         let route = PassthroughSubject<Route, Never>()
-        
+
         // To HomeViewModel
         let onSelectCategoryFilter = PassthroughSubject<StoreFoodCategoryResponse?, Never>()
         let onToggleSort = PassthroughSubject<StoreSortType, Never>()
         let onTapOnlyBoss = PassthroughSubject<Void, Never>()
         let onTapOnlyRecentActivity = PassthroughSubject<Void, Never>()
     }
-    
+
     struct State {
         var stores: [StoreWithExtraResponse] = []
         var categoryFilter: StoreFoodCategoryResponse?
@@ -50,7 +54,7 @@ extension HomeListViewModel {
         let mapMaxDistance: Double?
         var advertisement: AdvertisementResponse?
     }
-    
+
     struct Config {
         let categoryFilter: StoreFoodCategoryResponse?
         let isOnlyRecentActivity: Bool
@@ -59,7 +63,7 @@ extension HomeListViewModel {
         let mapLocation: CLLocation?
         let mapMaxDistance: Double?
     }
-    
+
     enum Route {
         case pushStoreDetail(storeId: String)
         case pushBossStoreDetail(storeId: String)
@@ -67,13 +71,13 @@ extension HomeListViewModel {
         case presentCategoryFilter(CategoryFilterViewModel)
         case openUrl(String?)
     }
-    
+
     struct Dependency {
         let storeRepository: StoreRepository
         let advertisementRepository: AdvertisementRepository
         let logManager: LogManagerProtocol
         let deepLinkHandler: DeepLinkHandlerProtocol
-        
+
         init(
             storeRepository: StoreRepository = StoreRepositoryImpl(),
             advertisementRepository: AdvertisementRepository =  AdvertisementRepositoryImpl(),
@@ -88,21 +92,23 @@ extension HomeListViewModel {
     }
 }
 
-
 final class HomeListViewModel: BaseViewModel {
     let input = Input()
     let output: Output
     private var state: State
     private let dependency: Dependency
-    
+
     init(config: Config, dependency: Dependency = Dependency()) {
+        let initialDatasource = HomeListViewModel.makeFilterDatasource(
+            categoryFilter: config.categoryFilter,
+            isOnlyRecentActivity: config.isOnlyRecentActivity,
+            sortType: config.sortType,
+            isOnlyBossStore: config.isOnlyBossStore
+        )
         self.output = Output(
-            filterDatasource: .init([
-                .category(config.categoryFilter),
-                .recentActivity(config.isOnlyRecentActivity),
-                .sortingFilter(config.sortType),
-                .onlyBoss(config.isOnlyBossStore)
-            ])
+            filterDatasource: .init(initialDatasource),
+            categoryFilter: .init(config.categoryFilter),
+            isOnlyBoss: .init(config.isOnlyBossStore)
         )
         self.state = State(
             categoryFilter: config.categoryFilter,
@@ -115,10 +121,10 @@ final class HomeListViewModel: BaseViewModel {
         )
         self.dependency = dependency
         super.init()
-        
+
         bindRelay()
     }
-    
+
     override func bind() {
         input.viewDidLoad
             .withUnretained(self)
@@ -126,7 +132,7 @@ final class HomeListViewModel: BaseViewModel {
                 owner.fetchDatas()
             }
             .store(in: &cancellables)
-        
+
         input.willDisplay
             .removeDuplicates()
             .withUnretained(self)
@@ -137,7 +143,7 @@ final class HomeListViewModel: BaseViewModel {
                 owner.fetchAroundStore()
             })
             .store(in: &cancellables)
-        
+
         input.onTapCategoryFilter
             .withUnretained(self)
             .sink { owner, _ in
@@ -145,7 +151,7 @@ final class HomeListViewModel: BaseViewModel {
                 owner.presentCategoryFilter()
             }
             .store(in: &cancellables)
-        
+
         input.selectCategory
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, category: StoreFoodCategoryResponse?) in
@@ -155,7 +161,7 @@ final class HomeListViewModel: BaseViewModel {
                 owner.fetchAroundStore()
             })
             .store(in: &cancellables)
-        
+
         input.onTapOnlyRecentActivity
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, _) in
@@ -166,7 +172,7 @@ final class HomeListViewModel: BaseViewModel {
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onToggleCertifiedStore
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, _) in
@@ -178,10 +184,10 @@ final class HomeListViewModel: BaseViewModel {
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onToggleSort
             .withUnretained(self)
-            .sink(receiveValue: { (owner: HomeListViewModel, sortType: StoreSortType) in
+            .sink(receiveValue: { (owner: HomeListViewModel, _: StoreSortType) in
                 owner.clearData()
                 owner.state.sortType = owner.state.sortType.toggled()
                 owner.sendClickSortingLog(owner.state.sortType)
@@ -189,7 +195,7 @@ final class HomeListViewModel: BaseViewModel {
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onTapOnlyBoss
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, _) in
@@ -200,12 +206,12 @@ final class HomeListViewModel: BaseViewModel {
                 owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
-        
+
         input.onTapStore
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, storeWithExtra: StoreWithExtraResponse) in
                 owner.sendClickStore(storeWithExtra.store)
-                
+
                 switch storeWithExtra.store.storeType {
                 case .bossStore:
                     owner.output.route.send(.pushBossStoreDetail(storeId: storeWithExtra.store.storeId))
@@ -216,7 +222,7 @@ final class HomeListViewModel: BaseViewModel {
                 }
             })
             .store(in: &cancellables)
-        
+
         input.onTapAdvertisement
             .withUnretained(self)
             .sink { owner, advertisement in
@@ -226,43 +232,128 @@ final class HomeListViewModel: BaseViewModel {
                 owner.dependency.deepLinkHandler.handleAdvertisementLink(link)
             }
             .store(in: &cancellables)
+
+        input.onTapRadioOption
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeListViewModel, payload: (paramKey: String, optionIndex: Int)) in
+                // chip 탭을 기존 typed input 으로 라우팅 — 기존 처리 흐름 재사용
+                switch payload.paramKey {
+                case "filterConditions":
+                    owner.input.onTapOnlyRecentActivity.send(())
+                case "sortType":
+                    owner.input.onToggleSort.send(owner.state.sortType)
+                case "targetStores":
+                    owner.input.onTapOnlyBoss.send(())
+                default:
+                    break
+                }
+            })
+            .store(in: &cancellables)
+
+        input.onTapActionLink
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeListViewModel, link: SDLink) in
+                owner.dependency.deepLinkHandler.handleLinkResponse(link)
+            })
+            .store(in: &cancellables)
     }
-    
+
     private func bindRelay() {
         input.onToggleSort
             .subscribe(output.onToggleSort)
             .store(in: &cancellables)
-        
+
         input.onTapOnlyBoss
             .subscribe(output.onTapOnlyBoss)
             .store(in: &cancellables)
-        
+
         input.selectCategory
             .subscribe(output.onSelectCategoryFilter)
             .store(in: &cancellables)
-        
+
         input.onTapOnlyRecentActivity
             .subscribe(output.onTapOnlyRecentActivity)
             .store(in: &cancellables)
     }
-    
+
     private func updateFilterDatasource() {
-        let datasource: [HomeFilterCollectionView.CellType] = [
-            .category(state.categoryFilter),
-            .recentActivity(state.isOnlyRecentActivity),
-            .sortingFilter(state.sortType),
-            .onlyBoss(state.isOnlyBossStore)
-        ]
-        
+        let datasource = HomeListViewModel.makeFilterDatasource(
+            categoryFilter: state.categoryFilter,
+            isOnlyRecentActivity: state.isOnlyRecentActivity,
+            sortType: state.sortType,
+            isOnlyBossStore: state.isOnlyBossStore
+        )
         output.filterDatasource.send(datasource)
+        output.categoryFilter.send(state.categoryFilter)
+        output.isOnlyBoss.send(state.isOnlyBossStore)
     }
-    
+
+    /// 정적 fallback chip 합성 — HomeListViewController 의 필터 영역도 chip 기반으로 렌더하기 위해.
+    /// SDUI 가 본 화면용으로 분리되기 전까지 사용.
+    static func makeFilterDatasource(
+        categoryFilter: StoreFoodCategoryResponse?,
+        isOnlyRecentActivity: Bool,
+        sortType: StoreSortType,
+        isOnlyBossStore: Bool
+    ) -> [HomeFilterCollectionView.CellType] {
+        let categoriesChip = SDChip(
+            image: nil,
+            text: SDText(text: "음식 종류", isHtml: false, fontColor: "#5A5A5A"),
+            style: nil
+        )
+        var cells: [HomeFilterCollectionView.CellType] = [
+            .chip(categoriesChip, surface: nil, action: .openCategoryFilter)
+        ]
+        if let categoryFilter {
+            let chip = SDChip(
+                image: SDImage(url: categoryFilter.imageUrl, style: SDImageStyle(width: 16, height: 16)),
+                text: SDText(text: categoryFilter.name, isHtml: false, fontColor: "#FF858F"),
+                style: nil
+            )
+            cells.append(.chip(chip, surface: nil, action: .openCategoryFilter))
+        }
+        // 영업중 (filterConditions): paramValue=null 전체, "RECENT_ACTIVITY" 영업중
+        let recentActivityChip = SDChip(
+            image: nil,
+            text: SDText(text: "🔥 영업 중", isHtml: false, fontColor: isOnlyRecentActivity ? "#FF858F" : "#5A5A5A"),
+            style: nil
+        )
+        cells.append(.chip(
+            recentActivityChip,
+            surface: nil,
+            action: .selectRadio(paramKey: "filterConditions", optionIndex: isOnlyRecentActivity ? 1 : 0)
+        ))
+        // 정렬 (sortType)
+        let sortChip = SDChip(
+            image: nil,
+            text: SDText(text: sortType == .distanceAsc ? "거리순" : "최신순", isHtml: false, fontColor: "#5A5A5A"),
+            style: nil
+        )
+        cells.append(.chip(
+            sortChip,
+            surface: nil,
+            action: .selectRadio(paramKey: "sortType", optionIndex: sortType == .distanceAsc ? 0 : 1)
+        ))
+        // 사장님 직영점 (targetStores)
+        let bossChip = SDChip(
+            image: nil,
+            text: SDText(text: "🧑‍🍳 사장님 직영", isHtml: false, fontColor: isOnlyBossStore ? "#FF858F" : "#5A5A5A"),
+            style: nil
+        )
+        cells.append(.chip(
+            bossChip,
+            surface: nil,
+            action: .selectRadio(paramKey: "targetStores", optionIndex: isOnlyBossStore ? 1 : 0)
+        ))
+        return cells
+    }
+
     private func canLoad(index: Int) -> Bool {
         var contentsCount = state.stores.count
         contentsCount += 2 // 광고 카운트
         return index >= contentsCount - 1 && state.nextCursor != nil && state.hasMore
     }
-    
+
     private func fetchAroundStore() {
         Task {
             let input = createFetchAroundStoreInput()
@@ -280,15 +371,15 @@ final class HomeListViewModel: BaseViewModel {
         }
         .store(in: taskBag)
     }
-    
+
     private func createFetchAroundStoreInput() -> FetchAroundStoreInput {
-        var categoryIds: [String]? = nil
+        var categoryIds: [String]?
         if let filterCategory = state.categoryFilter {
             categoryIds = [filterCategory.categoryId]
         }
         let targetStores: [StoreType] = state.isOnlyBossStore ? [.bossStore] : [.userStore, .bossStore]
         let filterConditions: [ActivitiesStatus] = state.isOnlyRecentActivity ? [.recentActivity] : [.recentActivity, .noRecentActivity]
-        
+
         return FetchAroundStoreInput(
             distanceM: state.mapMaxDistance ?? 0,
             categoryIds: categoryIds,
@@ -302,7 +393,7 @@ final class HomeListViewModel: BaseViewModel {
             mapLongitude: state.mapLocation?.coordinate.longitude ?? 0
         )
     }
-    
+
     private func fetchDatas() {
         Task { [weak self] in
             guard let self else { return }
@@ -325,37 +416,37 @@ final class HomeListViewModel: BaseViewModel {
         }
         .store(in: taskBag)
     }
-    
+
     private func updateDataSource() {
         var sectionItems = state.stores.map { HomeListSectionItem.store($0) }
-        
+
         if sectionItems.isEmpty {
             sectionItems.append(.emptyStore)
         }
-        
+
         let admobIndex = min(0, sectionItems.count)
         sectionItems.insert(.admob, at: admobIndex)
-        
+
         let index = min(1, sectionItems.count) // 두번째 구좌에 노출
         let config = HomeListAdCellViewModel.Config(ad: state.advertisement)
         let viewModel = HomeListAdCellViewModel(config: config)
-        
+
         sectionItems.insert(.ad(viewModel), at: index)
-        
+
         output.dataSource.send([HomeListSection(items: sectionItems)])
     }
-    
+
     private func presentCategoryFilter() {
         let config = CategoryFilterViewModel.Config(currentCategory: state.categoryFilter)
         let viewModel = CategoryFilterViewModel(config: config)
-        
+
         viewModel.output.didSelectCategory
             .subscribe(input.selectCategory)
             .store(in: &viewModel.cancellables)
-        
+
         output.route.send(.presentCategoryFilter(viewModel))
     }
-    
+
     private func clearData() {
         state.nextCursor = nil
         state.hasMore = false
@@ -435,23 +526,19 @@ extension HomeListViewModel: HomeFilterSelectable {
     var onTapCategoryFilter: PassthroughSubject<Void, Never> {
         return input.onTapCategoryFilter
     }
-    
-    var onTapOnlyRecentActivity: PassthroughSubject<Void, Never> {
-        return input.onTapOnlyRecentActivity
+
+    var onTapRadioOption: PassthroughSubject<(paramKey: String, optionIndex: Int), Never> {
+        return input.onTapRadioOption
     }
-    
-    var onToggleSort: PassthroughSubject<Model.StoreSortType, Never> {
-        return input.onToggleSort
+
+    var onTapActionLink: PassthroughSubject<SDLink, Never> {
+        return input.onTapActionLink
     }
-    
-    var onTapOnlyBoss: PassthroughSubject<Void, Never> {
-        return input.onTapOnlyBoss
-    }
-    
+
     var selectCategory: PassthroughSubject<StoreFoodCategoryResponse?, Never> {
         return input.selectCategory
     }
-    
+
     var filterDatasource: CurrentValueSubject<[HomeFilterCollectionView.CellType], Never> {
         return output.filterDatasource
     }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/HomeList/HomeListViewModel.swift
@@ -16,10 +16,8 @@ extension HomeListViewModel {
         let onTapCategoryFilter = PassthroughSubject<Void, Never>()
         let onTapRadioOption = PassthroughSubject<(paramKey: String, optionIndex: Int), Never>()
         let onTapActionLink = PassthroughSubject<SDLink, Never>()
-        let onTapOnlyRecentActivity = PassthroughSubject<Void, Never>()
+        let onTapCloseSelectedCategory = PassthroughSubject<Void, Never>()
         let selectCategory = PassthroughSubject<StoreFoodCategoryResponse?, Never>()
-        let onToggleSort = PassthroughSubject<StoreSortType, Never>()
-        let onTapOnlyBoss = PassthroughSubject<Void, Never>()
         let onToggleCertifiedStore = PassthroughSubject<Void, Never>()
         let onTapStore = PassthroughSubject<StoreWithExtraResponse, Never>()
         let onTapAdvertisement = PassthroughSubject<AdvertisementResponse?, Never>()
@@ -36,32 +34,49 @@ extension HomeListViewModel {
 
         // To HomeViewModel
         let onSelectCategoryFilter = PassthroughSubject<StoreFoodCategoryResponse?, Never>()
-        let onToggleSort = PassthroughSubject<StoreSortType, Never>()
-        let onTapOnlyBoss = PassthroughSubject<Void, Never>()
-        let onTapOnlyRecentActivity = PassthroughSubject<Void, Never>()
+        let onTapRadioOption = PassthroughSubject<(paramKey: String, optionIndex: Int), Never>()
     }
 
     struct State {
         var stores: [StoreWithExtraResponse] = []
         var categoryFilter: StoreFoodCategoryResponse?
-        var isOnlyRecentActivity: Bool
-        var sortType: StoreSortType
+        // 정적 typed targetStores 와 output.isOnlyBoss 용. SDU radioSelection["targetStores"] 와 동기화된다.
         var isOnlyBossStore: Bool
+        // SDU 가 아닌 리스트 화면 전용 토글 (인증 가게만). dynamicParams 로 주입.
         var isOnlyCertifiedStore = false
         var mapLocation: CLLocation?
         var nextCursor: String?
         var hasMore: Bool
         let mapMaxDistance: Double?
         var advertisement: AdvertisementResponse?
+        // 홈 화면에서 받은 SDU 필터 스냅샷. chip 렌더링과 dynamicParams 합성의 단일 출처.
+        var filterSections: [any HomeScreenSection] = []
+        var radioSelection: [String: Int] = [:]
     }
 
     struct Config {
         let categoryFilter: StoreFoodCategoryResponse?
-        let isOnlyRecentActivity: Bool
-        let sortType: StoreSortType
         let isOnlyBossStore: Bool
         let mapLocation: CLLocation?
         let mapMaxDistance: Double?
+        let filterSections: [any HomeScreenSection]
+        let radioSelection: [String: Int]
+
+        public init(
+            categoryFilter: StoreFoodCategoryResponse?,
+            isOnlyBossStore: Bool,
+            mapLocation: CLLocation?,
+            mapMaxDistance: Double?,
+            filterSections: [any HomeScreenSection] = [],
+            radioSelection: [String: Int] = [:]
+        ) {
+            self.categoryFilter = categoryFilter
+            self.isOnlyBossStore = isOnlyBossStore
+            self.mapLocation = mapLocation
+            self.mapMaxDistance = mapMaxDistance
+            self.filterSections = filterSections
+            self.radioSelection = radioSelection
+        }
     }
 
     enum Route {
@@ -100,10 +115,9 @@ final class HomeListViewModel: BaseViewModel {
 
     init(config: Config, dependency: Dependency = Dependency()) {
         let initialDatasource = HomeListViewModel.makeFilterDatasource(
-            categoryFilter: config.categoryFilter,
-            isOnlyRecentActivity: config.isOnlyRecentActivity,
-            sortType: config.sortType,
-            isOnlyBossStore: config.isOnlyBossStore
+            filterSections: config.filterSections,
+            radioSelection: config.radioSelection,
+            categoryFilter: config.categoryFilter
         )
         self.output = Output(
             filterDatasource: .init(initialDatasource),
@@ -112,12 +126,12 @@ final class HomeListViewModel: BaseViewModel {
         )
         self.state = State(
             categoryFilter: config.categoryFilter,
-            isOnlyRecentActivity: config.isOnlyRecentActivity,
-            sortType: config.sortType,
             isOnlyBossStore: config.isOnlyBossStore,
             mapLocation: config.mapLocation,
             hasMore: true,
-            mapMaxDistance: config.mapMaxDistance
+            mapMaxDistance: config.mapMaxDistance,
+            filterSections: config.filterSections,
+            radioSelection: config.radioSelection
         )
         self.dependency = dependency
         super.init()
@@ -162,17 +176,6 @@ final class HomeListViewModel: BaseViewModel {
             })
             .store(in: &cancellables)
 
-        input.onTapOnlyRecentActivity
-            .withUnretained(self)
-            .sink(receiveValue: { (owner: HomeListViewModel, _) in
-                owner.state.isOnlyRecentActivity.toggle()
-                owner.clearData()
-                owner.sendClickRecentActivityFilter(value: owner.state.isOnlyRecentActivity)
-                owner.fetchAroundStore()
-                owner.updateFilterDatasource()
-            })
-            .store(in: &cancellables)
-
         input.onToggleCertifiedStore
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, _) in
@@ -180,28 +183,6 @@ final class HomeListViewModel: BaseViewModel {
                 owner.state.isOnlyCertifiedStore.toggle()
                 owner.sendClickOnlyVisitFilterLog(owner.state.isOnlyCertifiedStore)
                 owner.output.isOnlyCertified.send(owner.state.isOnlyCertifiedStore)
-                owner.fetchAroundStore()
-                owner.updateFilterDatasource()
-            })
-            .store(in: &cancellables)
-
-        input.onToggleSort
-            .withUnretained(self)
-            .sink(receiveValue: { (owner: HomeListViewModel, _: StoreSortType) in
-                owner.clearData()
-                owner.state.sortType = owner.state.sortType.toggled()
-                owner.sendClickSortingLog(owner.state.sortType)
-                owner.fetchAroundStore()
-                owner.updateFilterDatasource()
-            })
-            .store(in: &cancellables)
-
-        input.onTapOnlyBoss
-            .withUnretained(self)
-            .sink(receiveValue: { (owner: HomeListViewModel, _) in
-                owner.clearData()
-                owner.state.isOnlyBossStore.toggle()
-                owner.sendClickOnlyBossFilterLog(owner.state.isOnlyBossStore)
                 owner.fetchAroundStore()
                 owner.updateFilterDatasource()
             })
@@ -236,66 +217,182 @@ final class HomeListViewModel: BaseViewModel {
         input.onTapRadioOption
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, payload: (paramKey: String, optionIndex: Int)) in
-                // chip 탭을 기존 typed input 으로 라우팅 — 기존 처리 흐름 재사용
-                switch payload.paramKey {
-                case "filterConditions":
-                    owner.input.onTapOnlyRecentActivity.send(())
-                case "sortType":
-                    owner.input.onToggleSort.send(owner.state.sortType)
-                case "targetStores":
-                    owner.input.onTapOnlyBoss.send(())
-                default:
-                    break
-                }
+                owner.applyRadioSelection(paramKey: payload.paramKey, optionIndex: payload.optionIndex)
+                owner.clearData()
+                owner.fetchAroundStore()
+                owner.updateFilterDatasource()
             })
             .store(in: &cancellables)
 
         input.onTapActionLink
             .withUnretained(self)
             .sink(receiveValue: { (owner: HomeListViewModel, link: SDLink) in
+                owner.sendActionBarClickLog(for: link)
                 owner.dependency.deepLinkHandler.handleLinkResponse(link)
+            })
+            .store(in: &cancellables)
+
+        input.onTapCloseSelectedCategory
+            .withUnretained(self)
+            .sink(receiveValue: { (owner: HomeListViewModel, _) in
+                owner.sendCurrentCategoryCloseLog()
+                owner.input.selectCategory.send(nil)
             })
             .store(in: &cancellables)
     }
 
     private func bindRelay() {
-        input.onToggleSort
-            .subscribe(output.onToggleSort)
-            .store(in: &cancellables)
-
-        input.onTapOnlyBoss
-            .subscribe(output.onTapOnlyBoss)
-            .store(in: &cancellables)
-
         input.selectCategory
             .subscribe(output.onSelectCategoryFilter)
             .store(in: &cancellables)
 
-        input.onTapOnlyRecentActivity
-            .subscribe(output.onTapOnlyRecentActivity)
+        input.onTapRadioOption
+            .subscribe(output.onTapRadioOption)
             .store(in: &cancellables)
+    }
+
+    private func applyRadioSelection(paramKey: String, optionIndex: Int) {
+        state.radioSelection[paramKey] = optionIndex
+        let paramValue = currentParamValue(for: paramKey, fallbackOptionIndex: optionIndex)
+
+        // 정적 typed targetStores 와 output.isOnlyBoss 가 SDU 선택과 어긋나지 않도록 동기화한다.
+        if paramKey == "targetStores" {
+            state.isOnlyBossStore = (paramValue == "BOSS_STORE")
+            output.isOnlyBoss.send(state.isOnlyBossStore)
+        }
+
+        switch paramKey {
+        case "filterConditions":
+            sendClickRecentActivityFilter(value: paramValue == "RECENT_ACTIVITY")
+        case "sortType":
+            if let value = paramValue, let sortType = StoreSortType(rawValue: value) {
+                sendClickSortingLog(sortType)
+            }
+        case "targetStores":
+            sendClickOnlyBossFilterLog(paramValue == "BOSS_STORE")
+        default:
+            // 신규 paramKey 는 분석 이벤트 추가 시 case 분리.
+            break
+        }
+
+        sendClickFilterLog(paramKey: paramKey, optionIndex: optionIndex)
+    }
+
+    private func sendClickFilterLog(paramKey: String, optionIndex: Int) {
+        guard let radioBar = allBars
+            .compactMap({ $0 as? HomeFilterRadioBar })
+            .first(where: { $0.paramKey == paramKey }),
+              let option = radioBar.options[safe: optionIndex],
+              let clickLog = option.clickLog else { return }
+        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+    }
+
+    private func sendActionBarClickLog(for link: SDLink) {
+        let actionBar = allBars
+            .compactMap { $0 as? HomeFilterActionBar }
+            .first { $0.button.link == link }
+        guard let clickLog = actionBar?.clickLog else { return }
+        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+    }
+
+    private func sendCurrentCategoryCloseLog() {
+        let currentCategory = allBars
+            .compactMap { $0 as? HomeFilterCategoryBar }
+            .first?
+            .currentCategoryFilter
+        guard let clickLog = currentCategory?.clickLog else { return }
+        dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+    }
+
+    /// SDU 응답에서 paramValue 를 우선 조회. 응답이 없으면 fallback chip 의 optionIndex(0/1) 로 추정한다.
+    private func currentParamValue(for paramKey: String, fallbackOptionIndex: Int) -> String? {
+        if let radioBar = allBars.compactMap({ $0 as? HomeFilterRadioBar }).first(where: { $0.paramKey == paramKey }),
+           let value = radioBar.options[safe: fallbackOptionIndex]?.paramValue {
+            return value
+        }
+        // 정적 fallback 매핑 (SDU 응답이 없을 때만 사용).
+        switch paramKey {
+        case "filterConditions":
+            return fallbackOptionIndex == 1 ? "RECENT_ACTIVITY" : nil
+        case "sortType":
+            return fallbackOptionIndex == 1 ? "LATEST" : "DISTANCE_ASC"
+        case "targetStores":
+            return fallbackOptionIndex == 1 ? "BOSS_STORE" : nil
+        default:
+            return nil
+        }
+    }
+
+    private var allBars: [any HomeFilterBar] {
+        state.filterSections
+            .compactMap { $0 as? HomeFilterSection }
+            .flatMap(\.bars)
     }
 
     private func updateFilterDatasource() {
         let datasource = HomeListViewModel.makeFilterDatasource(
-            categoryFilter: state.categoryFilter,
-            isOnlyRecentActivity: state.isOnlyRecentActivity,
-            sortType: state.sortType,
-            isOnlyBossStore: state.isOnlyBossStore
+            filterSections: state.filterSections,
+            radioSelection: state.radioSelection,
+            categoryFilter: state.categoryFilter
         )
         output.filterDatasource.send(datasource)
         output.categoryFilter.send(state.categoryFilter)
         output.isOnlyBoss.send(state.isOnlyBossStore)
     }
 
-    /// 정적 fallback chip 합성 — HomeListViewController 의 필터 영역도 chip 기반으로 렌더하기 위해.
-    /// SDUI 가 본 화면용으로 분리되기 전까지 사용.
+    /// SDU 응답이 있으면 홈 화면과 동일한 chip 을 렌더하고, 없으면 정적 fallback 으로 합성한다.
     static func makeFilterDatasource(
-        categoryFilter: StoreFoodCategoryResponse?,
-        isOnlyRecentActivity: Bool,
-        sortType: StoreSortType,
-        isOnlyBossStore: Bool
+        filterSections: [any HomeScreenSection],
+        radioSelection: [String: Int],
+        categoryFilter: StoreFoodCategoryResponse?
     ) -> [HomeFilterCollectionView.CellType] {
+        let allBars = filterSections
+            .compactMap { $0 as? HomeFilterSection }
+            .flatMap(\.bars)
+
+        guard allBars.isEmpty.isNot else {
+            return makeFallbackDatasource(
+                radioSelection: radioSelection,
+                categoryFilter: categoryFilter
+            )
+        }
+
+        var cells: [HomeFilterCollectionView.CellType] = []
+        for bar in allBars {
+            switch bar {
+            case let categoryBar as HomeFilterCategoryBar:
+                cells.append(.chip(categoryBar.categoriesFilter, surface: nil, action: .openCategoryFilter))
+                if let category = categoryFilter {
+                    let fontColor = categoryBar.currentCategoryFilter?.fontColor ?? "#000000"
+                    let chip = makeSelectedCategoryChip(category: category, fontColor: fontColor)
+                    cells.append(.selectedCategoryChip(chip, current: categoryBar.currentCategoryFilter))
+                }
+            case let radioBar as HomeFilterRadioBar:
+                let selectedIndex = radioSelection[radioBar.paramKey] ?? 0
+                guard radioBar.options.isEmpty.isNot,
+                      let currentOption = radioBar.options[safe: selectedIndex] else { break }
+                let nextIndex = (selectedIndex + 1) % radioBar.options.count
+                let surface: SDSurfaceStyle? = selectedIndex == 0 ? nil : selectedSurface(for: currentOption.chip)
+                let action = HomeFilterCollectionView.ChipAction.selectRadio(paramKey: radioBar.paramKey, optionIndex: nextIndex)
+                cells.append(.chip(currentOption.chip, surface: surface, action: action))
+            case let actionBar as HomeFilterActionBar:
+                cells.append(.button(actionBar.button, surface: nil))
+            default:
+                break
+            }
+        }
+        return cells
+    }
+
+    /// SDU 응답이 없을 때 사용. 활성/비활성 상태와 다음 optionIndex 모두 radioSelection 에서 직접 파생.
+    private static func makeFallbackDatasource(
+        radioSelection: [String: Int],
+        categoryFilter: StoreFoodCategoryResponse?
+    ) -> [HomeFilterCollectionView.CellType] {
+        let isOnlyRecentActivity = (radioSelection["filterConditions"] ?? 0) == 1
+        let isLatestSort = (radioSelection["sortType"] ?? 0) == 1
+        let isOnlyBossStore = (radioSelection["targetStores"] ?? 0) == 1
+
         let categoriesChip = SDChip(
             image: nil,
             text: SDText(text: "음식 종류", isHtml: false, fontColor: "#5A5A5A"),
@@ -305,14 +402,10 @@ final class HomeListViewModel: BaseViewModel {
             .chip(categoriesChip, surface: nil, action: .openCategoryFilter)
         ]
         if let categoryFilter {
-            let chip = SDChip(
-                image: SDImage(url: categoryFilter.imageUrl, style: SDImageStyle(width: 16, height: 16)),
-                text: SDText(text: categoryFilter.name, isHtml: false, fontColor: "#FF858F"),
-                style: nil
-            )
+            let chip = makeSelectedCategoryChip(category: categoryFilter, fontColor: "#FF858F")
             cells.append(.chip(chip, surface: nil, action: .openCategoryFilter))
         }
-        // 영업중 (filterConditions): paramValue=null 전체, "RECENT_ACTIVITY" 영업중
+        // optionIndex 는 "탭 후 전환될 다음 인덱스" 를 의미 (SDU chip 과 동일 규약).
         let recentActivityChip = SDChip(
             image: nil,
             text: SDText(text: "🔥 영업 중", isHtml: false, fontColor: isOnlyRecentActivity ? "#FF858F" : "#5A5A5A"),
@@ -321,20 +414,18 @@ final class HomeListViewModel: BaseViewModel {
         cells.append(.chip(
             recentActivityChip,
             surface: nil,
-            action: .selectRadio(paramKey: "filterConditions", optionIndex: isOnlyRecentActivity ? 1 : 0)
+            action: .selectRadio(paramKey: "filterConditions", optionIndex: isOnlyRecentActivity ? 0 : 1)
         ))
-        // 정렬 (sortType)
         let sortChip = SDChip(
             image: nil,
-            text: SDText(text: sortType == .distanceAsc ? "거리순" : "최신순", isHtml: false, fontColor: "#5A5A5A"),
+            text: SDText(text: isLatestSort ? "최신순" : "거리순", isHtml: false, fontColor: "#5A5A5A"),
             style: nil
         )
         cells.append(.chip(
             sortChip,
             surface: nil,
-            action: .selectRadio(paramKey: "sortType", optionIndex: sortType == .distanceAsc ? 0 : 1)
+            action: .selectRadio(paramKey: "sortType", optionIndex: isLatestSort ? 0 : 1)
         ))
-        // 사장님 직영점 (targetStores)
         let bossChip = SDChip(
             image: nil,
             text: SDText(text: "🧑‍🍳 사장님 직영", isHtml: false, fontColor: isOnlyBossStore ? "#FF858F" : "#5A5A5A"),
@@ -343,9 +434,27 @@ final class HomeListViewModel: BaseViewModel {
         cells.append(.chip(
             bossChip,
             surface: nil,
-            action: .selectRadio(paramKey: "targetStores", optionIndex: isOnlyBossStore ? 1 : 0)
+            action: .selectRadio(paramKey: "targetStores", optionIndex: isOnlyBossStore ? 0 : 1)
         ))
         return cells
+    }
+
+    private static func selectedSurface(for chip: SDChip) -> SDSurfaceStyle? {
+        guard let background = chip.style?.backgroundColor else { return nil }
+        return SDSurfaceStyle(
+            backgroundColor: background,
+            borderColor: chip.text.fontColor,
+            borderWidth: 1,
+            cornerRadius: 10
+        )
+    }
+
+    private static func makeSelectedCategoryChip(category: StoreFoodCategoryResponse, fontColor: String) -> SDChip {
+        SDChip(
+            image: SDImage(url: category.imageUrl, style: SDImageStyle(width: 16, height: 16)),
+            text: SDText(text: category.name, isHtml: false, fontColor: fontColor),
+            style: nil
+        )
     }
 
     private func canLoad(index: Int) -> Bool {
@@ -378,20 +487,51 @@ final class HomeListViewModel: BaseViewModel {
             categoryIds = [filterCategory.categoryId]
         }
         let targetStores: [StoreType] = state.isOnlyBossStore ? [.bossStore] : [.userStore, .bossStore]
-        let filterConditions: [ActivitiesStatus] = state.isOnlyRecentActivity ? [.recentActivity] : [.recentActivity, .noRecentActivity]
 
         return FetchAroundStoreInput(
             distanceM: state.mapMaxDistance ?? 0,
             categoryIds: categoryIds,
             targetStores: targetStores,
-            sortType: state.sortType,
-            filterCertifiedStores: state.isOnlyCertifiedStore,
-            filterConditions: filterConditions,
             size: 10,
             cursor: state.nextCursor,
             mapLatitude: state.mapLocation?.coordinate.latitude ?? 0,
-            mapLongitude: state.mapLocation?.coordinate.longitude ?? 0
+            mapLongitude: state.mapLocation?.coordinate.longitude ?? 0,
+            dynamicParams: collectDynamicParams()
         )
+    }
+
+    private func collectDynamicParams() -> [String: String] {
+        var params: [String: String] = [:]
+        let radioBars = allBars.compactMap { $0 as? HomeFilterRadioBar }
+
+        if radioBars.isEmpty {
+            // SDU 응답이 없을 때 fallback chip 의 선택 상태를 paramValue 로 매핑.
+            for paramKey in ["filterConditions", "sortType"] {
+                let idx = state.radioSelection[paramKey] ?? 0
+                if let value = currentParamValue(for: paramKey, fallbackOptionIndex: idx) {
+                    params[paramKey] = value
+                }
+            }
+        } else {
+            // targetStores 는 정적 typed 필드로 직렬화되므로 dynamicParams 에서 제외해 중복 쿼리 키를 막는다.
+            for bar in radioBars where bar.paramKey != "targetStores" {
+                let idx = state.radioSelection[bar.paramKey] ?? 0
+                if let value = bar.options[safe: idx]?.paramValue {
+                    params[bar.paramKey] = value
+                }
+            }
+        }
+
+        // SDU 와 무관한 리스트 전용 필터. true 일 때만 포함.
+        if state.isOnlyCertifiedStore {
+            params["filterCertifiedStores"] = "true"
+        }
+
+        // sortType 은 서버 required 필드. 어떤 경로로도 채워지지 않은 경우 기본값으로 보강.
+        if params["sortType"] == nil {
+            params["sortType"] = "DISTANCE_ASC"
+        }
+        return params
     }
 
     private func fetchDatas() {
@@ -469,6 +609,13 @@ extension HomeListViewModel {
     }
 
     private func sendClickCategoryFilterLog() {
+        if let clickLog = allBars
+            .compactMap({ $0 as? HomeFilterCategoryBar })
+            .first?
+            .categoriesFilterClickLog {
+            dependency.logManager.sendEvent(event: SDClickEvent(clickLog: clickLog))
+            return
+        }
         dependency.logManager.sendEvent(event: ClickEvent(
             screen: output.screenName,
             objectType: .button,
@@ -533,6 +680,10 @@ extension HomeListViewModel: HomeFilterSelectable {
 
     var onTapActionLink: PassthroughSubject<SDLink, Never> {
         return input.onTapActionLink
+    }
+
+    var onTapCloseSelectedCategory: PassthroughSubject<Void, Never> {
+        return input.onTapCloseSelectedCategory
     }
 
     var selectCategory: PassthroughSubject<StoreFoodCategoryResponse?, Never> {

--- a/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteAddress/WriteAddressViewModel.swift
+++ b/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteAddress/WriteAddressViewModel.swift
@@ -158,7 +158,9 @@ public final class WriteAddressViewModel: BaseViewModel, WriteAddressViewModelIn
                 distanceM: 50,
                 targetStores: [.userStore, .bossStore],
                 mapLatitude: location.coordinate.latitude,
-                mapLongitude: location.coordinate.longitude
+                mapLongitude: location.coordinate.longitude,
+                // sortType 은 서버 required 필드라 SDU 흐름이 아닌 직접 호출에서도 명시한다.
+                dynamicParams: ["sortType": "DISTANCE_ASC"]
             )
             let result = await dependency.storeRepository.fetchAroundStores(input: input)
 

--- a/Tuist/ProjectDescriptionHelpers/Package+.swift
+++ b/Tuist/ProjectDescriptionHelpers/Package+.swift
@@ -19,4 +19,9 @@ public extension Package {
         url: "https://github.com/navermaps/SPM-NMapsMap",
         requirement: .exact("3.23.0")
     )
+
+    static let lookinServer = Package.remote(
+        url: "https://github.com/QMUI/LookinServer",
+        requirement: .exact("1.2.8")
+    )
 }

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
@@ -177,5 +177,7 @@ public extension TargetDependency {
         public static let admob = TargetDependency.package(product: "GoogleMobileAds")
         
         public static let naverMap = TargetDependency.package(product: "NMapsMap")
+
+        public static let lookinServer = TargetDependency.package(product: "LookinServer")
     }
 }


### PR DESCRIPTION
## 개요


## 리뷰어
- 1st :
- 2nd :

## 코드리뷰 완료 희망 날짜



---

## 주요 변경사항
홈 화면 필터를 서버 드리븐 UI(SDU)로 전환했습니다.

- **신규 API**: `GET /api/v1/screen/home` (`ScreenApi`, `ScreenRepository`)로 필터 구성을 서버에서 내려받아 렌더링
- **필터 모델**: `HomeFilterSection` / `HomeFilterCategoryBar` / `HomeFilterRadioBar` / `HomeFilterActionBar` 등 SDU 컴포넌트 추가, 공통 SDU foundation(`SDClickLog`, `SDBorder`)에 init 추가
- **요청 입력 변경**: `FetchAroundStoreInput`, `FetchHomeCardInput`에서 정적 필드(`sortType`, `filterCertifiedStores`, `filterConditions`) 제거 → `dynamicParams: [String: String]` 으로 직렬화
- **필터 UI 재구성**: `HomeFilterCell`이 `SDChip` / `SDButton` / 선택된 카테고리 chip(닫기 버튼 포함) 모두 처리, `HomeFilterCollectionView`의 `CellType`/`ChipAction` 도 SDU 기반으로 변경
- **로깅**: 서버 드리븐 로그 이벤트(`SDClickEvent`) 추가, 라디오/액션바 클릭/카테고리 닫기 등에서 사용
- **HomeViewModel / HomeListViewModel**:
  - 첫 `fetchHomeCards` 호출을 위치 + 필터 응답 모두 도착할 때까지 `CombineLatest`로 게이팅
  - `radioSelection` 상태와 legacy 정적 필드(`isOnlyBossStore`, `sortType`, `isOnlyRecentActivity`)를 양방향 동기화
  - 홈 ↔ 리스트 간 SDU 필터 스냅샷(`filterSections`, `radioSelection`) 전달
  - SDU 응답이 비었을 때 fallback chip 데이터소스 제공
- **기타**: 디버깅용 `LookinServer` 패키지 추가, 홈 필터 tooltip 위치 계산을 첫 RADIO_BAR cell 기준으로 변경

## 영향범위
- **홈 화면 (`HomeViewController` / `HomeView` / `HomeViewModel`)**: 필터 영역 전반, 첫 진입 시 home-cards 로딩 타이밍, 마커/카드 동기화
- **홈 리스트 화면 (`HomeListViewController` / `HomeListViewModel` / `HomeListDataSource` / `HomeListHeaderCell`)**: 헤더의 카테고리/사장님 토글 표시, SDU 필터 칩 렌더링
- **`HomeFilterCollectionView` / `HomeFilterCell`**: 칩/버튼/선택된 카테고리 렌더링 및 사이즈 계산
- **주소 작성 화면 (`WriteAddressViewModel`)**: `FetchAroundStoreInput.dynamicParams`로 `sortType` 직접 명시
- **공통 모델 (`Model` 모듈)**: `FetchAroundStoreInput`, `FetchHomeCardInput` 사용처(가게 주변/홈카드 호출 전 화면)

## 테스트
### 테스트 환경

### 테스트케이스 (요구사항, 기대결과)
- [ ] 홈 화면 첫 진입 시 필터 영역이 서버 응답대로 렌더링되고, 응답 도착 전에는 home-cards가 호출되지 않는다 (이중 호출/빈 결과 방지)
- [ ] 필터 응답 실패 시 fallback 필터(음식 종류 / 영업 중 / 거리순·최신순 / 사장님 직영)가 표시되고 정상 동작한다
- [ ] 카테고리 필터 칩 탭 → 카테고리 선택 모달 표시, 선택 시 chip이 selected 상태로 갱신, ✕ 버튼으로 해제 가능
- [ ] 라디오 옵션 칩 탭 시 다음 옵션으로 토글되고 home-cards가 변경된 `dynamicParams`로 재요청된다
- [ ] 액션바 버튼 탭 시 서버에서 내려준 deepLink로 라우팅된다
- [ ] 홈 → 리스트 진입 시 현재 필터 상태가 그대로 유지되고, 리스트에서 라디오를 토글하면 홈 chip 도 동일하게 갱신된다
- [ ] 사장님 직영 토글 시 홈 마커 / 리스트 헤더의 "인증된 가게만" 노출 여부가 모두 정상 갱신된다
- [ ] 서버 응답에 border/배경색 등이 포함될 때 chip 에 정상 반영되고, 셀 재사용 시 이전 스타일이 잔존하지 않는다 (`prepareForReuse`)
- [ ] 라디오/액션바/카테고리 닫기 클릭 시 서버 `clickLog`(screenName/objectType/objectId/extraParameters)가 그대로 GA로 전송된다
- [ ] 가게 등록(주소 검색) 화면에서 주변 가게 조회가 기존과 동일하게 동작한다 (`sortType=DISTANCE_ASC` 보강)
