### PR TITLE
TH-1210: 스플래시 이탈률 개선

### DIFF
--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashViewController.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashViewController.swift
@@ -23,6 +23,11 @@ final class SplashViewController: BaseViewController {
 
     private let viewModel = SplashViewModel()
 
+    // 백그라운드에서 복귀했을 때만 재로드하기 위한 플래그.
+    // 콜드런치 시점엔 willEnterForeground 발생이 보장되지 않으므로 viewDidLoad에서 직접 로드를 트리거하고,
+    // 이 플래그로 콜드런치 직후의 willEnterForeground 중복 호출만 걸러낸다.
+    private var wasInBackground = false
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -32,6 +37,7 @@ final class SplashViewController: BaseViewController {
 
         setupUI()
         setupNotification()
+        viewModel.input.load.send(())
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -90,6 +96,13 @@ final class SplashViewController: BaseViewController {
     }
 
     private func setupNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleWillEnterForeground),
@@ -185,7 +198,15 @@ final class SplashViewController: BaseViewController {
         }
     }
 
+    @objc private func handleDidEnterBackground() {
+        wasInBackground = true
+    }
+
     @objc private func handleWillEnterForeground() {
+        // 콜드런치 직후의 willEnterForeground(초기 로드와 중복)는 무시하고,
+        // 실제로 백그라운드에 다녀온 경우에만 재로드한다.
+        guard wasInBackground else { return }
+        wasInBackground = false
         viewModel.input.load.send(())
     }
 

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashViewModel.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/splash/SplashViewModel.swift
@@ -200,6 +200,9 @@ final class SplashViewModel: BaseViewModel {
             switch result {
             case .success(let user):
                 dependency.preference.userId = user.userId
+                // 토큰 검증이 끝나면 즉시 메인으로 진입시킨다.
+                // 푸시 토큰 갱신은 앱 진입과 무관하므로 진입을 막지 않도록 비차단으로 처리한다.
+                output.route.send(.goToMain)
                 refreshPushToken()
 
             case .failure(let error):
@@ -208,25 +211,21 @@ final class SplashViewModel: BaseViewModel {
         }.store(in: taskBag)
     }
 
+    // 푸시 토큰 갱신은 앱 진입을 막지 않는 fire-and-forget 작업이다.
+    // 실패하더라도 라우팅에는 영향을 주지 않고 관측용으로만 기록한다.
     private func refreshPushToken() {
+        guard let pushToken = dependency.preference.fcmToken else { return }
+
         Task { [weak self] in
             guard let self else { return }
 
-            if let pushToken = dependency.preference.fcmToken {
-                let input = UserDeviceUpsertRequest(pushPlatformType: "FCM", pushToken: pushToken)
-                let result = await dependency.deviceRepository.updateDevice(input: input)
+            let input = UserDeviceUpsertRequest(pushPlatformType: "FCM", pushToken: pushToken)
+            let result = await dependency.deviceRepository.updateDevice(input: input)
 
-                switch result {
-                case .success:
-                    output.route.send(.goToMain)
-                case .failure(let error):
-                    handleValidationError(error: error, context: .refreshPushTokenFailed(error))
-                }
-            } else {
-                output.route.send(.goToMain)
+            if case .failure(let error) = result {
+                logErrorToCrashlytics(splashError: .refreshPushTokenFailed(error))
             }
-        }
-
+        }.store(in: taskBag)
     }
 
     private func handleValidationError(error: Error, context: SplashError) {


### PR DESCRIPTION
## 작업 내용 (TH-1210)

스플래시 화면에서의 이탈률(bounce rate)을 개선합니다.

### 1. 초기 로드 트리거 방식 변경 (`SplashViewController`)
- `viewDidLoad`에서 `viewModel.input.load.send(())`를 **명시적으로 직접 호출**하도록 변경했습니다.
- 기존에는 `willEnterForeground` 알림에만 의존해 초기 로드를 트리거했는데, **콜드런치 시점엔 해당 알림 발생이 보장되지 않아** 로드가 트리거되지 않고 스플래시에 멈추는 케이스가 있었습니다.
- `wasInBackground` 플래그 + `didEnterBackground` 옵저버를 추가해, **실제로 백그라운드에 다녀온 경우에만 재로드**하고 콜드런치 직후의 중복 `willEnterForeground` 호출은 무시합니다.

### 2. 메인 진입 흐름 비차단 처리 (`SplashViewModel`)
- 토큰 검증이 끝나면 **즉시 `goToMain` 라우팅**하도록 변경했습니다.
- 푸시 토큰 갱신(`refreshPushToken`)은 앱 진입과 무관하므로 **fire-and-forget(비차단)** 으로 처리합니다. 실패하더라도 라우팅에는 영향을 주지 않고 Crashlytics 기록(관측)만 남깁니다.
- 기존에는 푸시 토큰 갱신 결과를 기다린 뒤 메인으로 진입해, 네트워크 지연/실패가 진입을 막는 요인이 되었습니다.

## 변경 이유
스플래시에 머무르다 이탈하는 비율을 줄이기 위해, 초기 로드의 신뢰성을 높이고(콜드런치 보장) 진입을 막는 비핵심 작업(푸시 토큰 갱신)을 진입 경로에서 분리했습니다.

## 리뷰어 참고 사항
- 콜드런치 / 백그라운드 복귀 / 푸시 토큰 갱신 실패 케이스에서 동작 확인이 필요합니다.
- 변경 파일: `SplashViewController.swift`, `SplashViewModel.swift`