### PR TITLE
TH-1214 : 가게 제보 주소 화면 마커의 위치 정확도 이슈 수정

### DIFF
--- a/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteAddress/WriteAddressViewController.swift
+++ b/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteAddress/WriteAddressViewController.swift
@@ -92,7 +92,9 @@ public final class WriteAddressViewController: BaseViewController {
     }
     
     private let viewModel: WriteAddressViewModel
-    
+
+    private var lastCameraChangeReason: Int = NMFMapChangedByDeveloper
+
     public init(viewModel: WriteAddressViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -143,7 +145,8 @@ public final class WriteAddressViewController: BaseViewController {
         }
         
         marker.snp.makeConstraints {
-            $0.center.equalTo(mapView)
+            $0.centerX.equalTo(mapView)
+            $0.bottom.equalTo(mapView.snp.centerY)
         }
         
         currentLocationButton.snp.makeConstraints {
@@ -290,15 +293,19 @@ extension WriteAddressViewController {
 }
 
 extension WriteAddressViewController: NMFMapViewCameraDelegate {
-    public func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
-        if animated && reason == NMFMapChangedByGesture {
-            let location = CLLocation(
-                latitude: mapView.cameraPosition.target.lat,
-                longitude: mapView.cameraPosition.target.lng
-            )
-            
-            viewModel.input.moveMapCenter.send(location)
-        }
+    public func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
+        lastCameraChangeReason = reason
+    }
+
+    public func mapViewCameraIdle(_ mapView: NMFMapView) {
+        guard lastCameraChangeReason == NMFMapChangedByGesture else { return }
+
+        let location = CLLocation(
+            latitude: mapView.cameraPosition.target.lat,
+            longitude: mapView.cameraPosition.target.lng
+        )
+
+        viewModel.input.moveMapCenter.send(location)
     }
 }
 


### PR DESCRIPTION
- 마커 이미지의 하단 중앙이 지도의 가운데를 가리키도록 위치 조정
- 지도를 1초 이상 길게 드래그 하다가 놓은 경우, 위치가 업데이트되지 않는 이슈 수정