### PR TITLE
TH-916 : 인앱브라우저에서 외부 링크 클릭 시 이동되지 않는 이슈 수정

### DIFF
--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/webview/WebView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/webview/WebView.swift
@@ -38,6 +38,7 @@ final class WebView: BaseView {
             topLineView,
             webView
         ])
+        webView.uiDelegate = self
     }
     
     override func bindConstraints() {
@@ -74,10 +75,25 @@ final class WebView: BaseView {
     
     func bind(webviewType: WebViewType) {
         titleLabel.text = webviewType.title
-        
+
         guard let url = URL(string: webviewType.url) else { return }
         let request = URLRequest(url: url)
-        
+
         webView.load(request)
+    }
+}
+
+extension WebView: WKUIDelegate {
+    // target="_blank" 링크는 새 창을 열 수 없어 무시되므로 현재 웹뷰에서 로드한다
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        if navigationAction.targetFrame.isNil {
+            webView.load(navigationAction.request)
+        }
+        return nil
     }
 }

--- a/App/Targets/three-dollar-in-my-pocket/Sources/domain/webview/WebView.swift
+++ b/App/Targets/three-dollar-in-my-pocket/Sources/domain/webview/WebView.swift
@@ -87,9 +87,9 @@ extension WebView: WKUIDelegate {
     // target="_blank" 링크는 새 창을 열 수 없어 무시되므로 현재 웹뷰에서 로드한다
     func webView(
         _ webView: WKWebView,
-        createWebViewWith configuration: WKWebViewConfiguration,
+        createWebViewWith _: WKWebViewConfiguration,
         for navigationAction: WKNavigationAction,
-        windowFeatures: WKWindowFeatures
+        windowFeatures _: WKWindowFeatures
     ) -> WKWebView? {
         if navigationAction.targetFrame.isNil {
             webView.load(navigationAction.request)


### PR DESCRIPTION
## 원인
`WebView`의 `WKWebView`에 `uiDelegate`가 설정되어 있지 않아, 웹 페이지 내 `target="_blank"` 링크를 탭하면 발생하는 새 창(new window) 생성 요청이 처리되지 못하고 무시됩니다. 길게 눌러 이동이 가능했던 것은 시스템 기본 컨텍스트 메뉴(미리보기)가 delegate 없이도 동작하기 때문입니다.

**문제 코드:** `WebView.swift` — `private let webView = WKWebView()` (line 31, delegate 미설정)

## 재현 경로
1. 딥링크/광고 등으로 인앱브라우저(WebViewController) 진입
2. 웹 페이지 내 `target="_blank"` 외부 링크 탭
3. 실제 결과: 아무 반응 없음 (길게 눌러 미리보기로만 이동 가능) / 기대 결과: 링크 페이지로 이동

## 수정 방향
`WebView`가 `WKUIDelegate`를 채택하고 `webView(_:createWebViewWith:for:windowFeatures:)`에서 `targetFrame`이 없는(새 창) 요청을 현재 웹뷰에서 로드하도록 처리했습니다. 인앱브라우저 특성상 새 창 대신 동일 웹뷰 내 이동이 기대 동작입니다.

**수정 내용:**
- `WebView.swift`: `webView.uiDelegate = self` 설정 및 `WKUIDelegate.createWebViewWith` 구현 추가

## 검증
- ✅ Debug 빌드 성공 (three-dollar-in-my-pocket-debug)
- ✅ SwiftLint 통과 (신규 코드 위반 없음)
- ✅ **시뮬레이터 Before/After 검증 PASS** (iPhone 17 Pro 시뮬레이터 / iOS 26.2, idb 기반 UI 자동화)
  - 시나리오: `dollars-dev://browser` 딥링크로 인앱브라우저 진입 → target="_blank" 링크가 있는 로컬 테스트 페이지에서 링크 탭
  - **Before (develop)**: 링크를 2회 탭해도 화면 변화 없음 (무반응) → 티켓 버그 재현 확인 ([영상](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-916-before.mp4))
  - **After (본 브랜치)**: 링크 탭 즉시 동일 웹뷰에서 대상 페이지로 이동 ([영상](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-916-after.mp4))

### 시뮬레이터 검증 스크린샷
| Before (develop) — 탭 후에도 그대로 | After (본 브랜치) — 대상 페이지 이동 |
|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-916-before.png" width="320"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-916-after.png" width="320"> |

## 영향 범위
- 인앱브라우저(WebViewController)를 사용하는 모든 진입점 (딥링크 browser 타입, 약관/FAQ 등 WebViewType 화면)
- **리스크:** 매우 낮음 (delegate 추가 + 새 창 요청 처리만 추가, 기존 내비게이션 동작 변경 없음)

## 관련 이슈
- Jira: TH-916

🤖 Generated with [Claude Code](https://claude.com/claude-code)