### PR TITLE
TH-1061 : 가게 제보 완료 화면 카테고리 태그 잘림 이슈 수정

### DIFF
--- a/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteDetail/WriteComplete/WriteCompleteViewController.swift
+++ b/Modules/Feature/Write/Targets/Write/Sources/Domains/WriteDetail/WriteComplete/WriteCompleteViewController.swift
@@ -53,8 +53,7 @@ final class WriteCompleteViewController: BaseViewController {
     
     private let storeCategoryStackView: UIStackView = {
         let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.distribution = .equalSpacing
+        stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 4
         return stackView
@@ -154,25 +153,23 @@ final class WriteCompleteViewController: BaseViewController {
         stackView.addArrangedSubview(titleLabel, previousSpace: 4)
         stackView.addArrangedSubview(overviewContainer, previousSpace: 12)
         
-        overviewContainer.snp.makeConstraints {
-            $0.height.equalTo(80)
-        }
-        
         overviewContainer.addSubViews([
             storeNameLabel,
             storeCategoryStackView
         ])
-        
+
         storeNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(16)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)
         }
-        
+
         storeCategoryStackView.snp.makeConstraints {
+            $0.top.equalTo(storeNameLabel.snp.bottom).offset(10)
             $0.centerX.equalToSuperview()
+            $0.leading.greaterThanOrEqualToSuperview().offset(16)
+            $0.trailing.lessThanOrEqualToSuperview().offset(-16)
             $0.bottom.equalToSuperview().offset(-16)
-            $0.height.equalTo(20)
         }
         
         stackView.addArrangedSubview(descriptionLabel, previousSpace: 28)
@@ -251,10 +248,40 @@ final class WriteCompleteViewController: BaseViewController {
     
     private func updateStoreCategory(_ categories: [StoreFoodCategoryResponse]) {
         storeCategoryStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        // 컨테이너 폭을 넘어가면 태그를 다음 행으로 줄바꿈한다
+        let maxRowWidth = view.frame.width
+            - stackView.layoutMargins.left - stackView.layoutMargins.right
+            - 32
+        var currentRow = createCategoryRowStackView()
+        var currentRowWidth: CGFloat = 0
+
         for category in categories {
             let tagView = CategoryTagView(category: category)
-            storeCategoryStackView.addArrangedSubview(tagView)
+            let tagWidth = tagView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+            let spacing: CGFloat = currentRow.arrangedSubviews.isEmpty ? 0 : 4
+
+            if currentRowWidth + spacing + tagWidth > maxRowWidth, currentRow.arrangedSubviews.isNotEmpty {
+                storeCategoryStackView.addArrangedSubview(currentRow)
+                currentRow = createCategoryRowStackView()
+                currentRowWidth = tagWidth
+            } else {
+                currentRowWidth += spacing + tagWidth
+            }
+            currentRow.addArrangedSubview(tagView)
         }
+
+        if currentRow.arrangedSubviews.isNotEmpty {
+            storeCategoryStackView.addArrangedSubview(currentRow)
+        }
+    }
+
+    private func createCategoryRowStackView() -> UIStackView {
+        let rowStackView = UIStackView()
+        rowStackView.axis = .horizontal
+        rowStackView.alignment = .center
+        rowStackView.spacing = 4
+        return rowStackView
     }
     
     private func updateAddAdditionalInfoButton(store: UserStoreResponse) {


### PR DESCRIPTION
## 원인
제보 완료 화면의 카테고리 태그 영역(`storeCategoryStackView`)이 가로 1행 스택뷰 + 높이 20 고정으로 구성되어 있고 폭 제약이 없어, 카테고리가 많거나 이름이 길면 `centerX` 기준으로 컨테이너(`overviewContainer`) 좌우 밖까지 늘어나 잘려 보입니다. 컨테이너도 높이 80 고정이라 2행으로 늘어날 수 없습니다.

**문제 코드:** `WriteCompleteViewController.swift` — `setupUI()`의 `storeCategoryStackView` 제약 (기존 line 172-176, `height.equalTo(20)` + 폭 제약 없음)

## 재현 경로
1. 가게 제보에서 이름이 긴 카테고리를 여러 개 선택하고 제보 완료
2. 제보 완료 화면(WriteCompleteViewController)의 가게 정보 카드 확인
3. 실제 결과: 카테고리 태그가 카드 좌우 밖으로 잘림 / 기대 결과: 폭 초과 시 다음 행으로 줄바꿈

## 수정 방향
카테고리 영역을 "세로 스택(행 컨테이너) + 행별 가로 스택" 구조로 변경하고, 태그 폭을 측정해 사용 가능한 폭을 초과하면 다음 행으로 넘기는 줄바꿈 로직을 추가했습니다. `overviewContainer`의 고정 높이(80)를 제거하고 내부 컨텐츠(가게명 + 카테고리 행 수) 기반으로 높이가 결정되도록 변경했습니다. 1행일 때의 기존 레이아웃은 거의 동일하게 유지됩니다.

**수정 내용:**
- `WriteCompleteViewController.swift`: `storeCategoryStackView`를 세로 축으로 변경, `updateStoreCategory`에 행 단위 줄바꿈 로직 추가, `overviewContainer`/카테고리 제약을 컨텐츠 기반으로 변경

## 검증
- ✅ Debug 빌드 성공 (three-dollar-in-my-pocket-debug)
- ✅ SwiftLint 통과 (신규 코드 위반 없음)
- ✅ **시뮬레이터 Before/After 검증 PASS** (iPhone 17 Pro 시뮬레이터 / iOS 26.2, idb 기반 UI 자동화)
  - 시나리오: 실제 제보 플로우로 카테고리 10개 선택 후 제보 완료 → 완료 화면 카드 확인
  - **Before (develop)**: 태그 10개가 1행으로 늘어서 카드 오른쪽에서 잘리고 나머지는 화면 밖으로 나감 → 티켓 버그 재현 확인
  - **After (본 브랜치)**: 태그 10개가 3행으로 줄바꿈되어 카드 안에 모두 표시, 카드 높이도 컨텐츠에 맞게 확장
  - 참고: 검증 과정에서 dev 서버에 테스트 가게가 생성되었습니다 (이름: `쏘1061-…`, `1061-2`, `1061-3` — 삭제해도 무방)

### 시뮬레이터 검증 스크린샷
| Before (develop) — 1행 고정, 좌우 잘림 | After (본 브랜치) — 3행 줄바꿈 |
|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-1061-before.png" width="320"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-1061-after.png" width="320"> |

## 영향 범위
- 가게 제보 완료 화면의 가게 정보 카드 (카테고리 1행일 때는 기존과 동일한 레이아웃)
- **리스크:** 낮음 (단일 화면의 레이아웃 변경, 서버 측에서도 카테고리 노출 개수를 제한 중)

## 관련 이슈
- Jira: TH-1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)