### PR TITLE
TH-1191 : 투표 댓글 신고 바텀시트가 화면 전체 높이로 표시되는 이슈 수정

### DIFF
--- a/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Report/ReportPollViewController.swift
+++ b/Modules/Feature/Community/Targets/Community/Sources/Domains/Poll/Report/ReportPollViewController.swift
@@ -64,6 +64,9 @@ final class ReportPollViewController: BaseViewController {
         self.viewModel = viewModel
 
         super.init(nibName: nil, bundle: nil)
+
+        // 하단 고정 containerView 방식의 시트라서 기본 pageSheet로 뜨면 상단에 빈 영역이 생긴다
+        modalPresentationStyle = .overCurrentContext
     }
 
     required init?(coder: NSCoder) {
@@ -73,9 +76,19 @@ final class ReportPollViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if let parentView = presentingViewController?.view {
+            DimManager.shared.showDim(targetView: parentView)
+        }
+
         setupUI()
 
         viewModel.input.firstLoad.send()
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
+
+        DimManager.shared.hideDim()
     }
 
     private func setupUI() {


### PR DESCRIPTION
## 원인
`ReportPollViewController`는 투명 배경 + 하단 고정 `containerView`로 구성된 오버레이형 바텀시트인데, `modalPresentationStyle` 지정 없이 기본 present(`.automatic` → `.pageSheet`)로 표시되고 있었습니다. pageSheet는 거의 전체 높이의 시트 카드를 만들기 때문에, containerView 위쪽이 전부 빈 영역으로 노출됩니다.

**문제 코드:** `PollDetailViewController.swift` — `route .report` 처리에서 `present(vc, animated: true)` (line 133) / `ReportPollViewController.swift` — `modalPresentationStyle` 미지정

같은 모듈의 동일 패턴 모달인 `CreatePollModalViewController`는 `modalPresentationStyle = .overCurrentContext` + `DimManager`로 정상 동작하고 있어, 해당 패턴이 누락된 케이스입니다.

## 재현 경로
1. 커뮤니티 탭 → 투표 상세 화면(PollDetailViewController) 진입
2. 다른 사용자가 등록한 댓글의 신고 버튼 탭
3. 실제 결과: 신고 바텀시트가 화면 전체 높이의 시트로 떠서 상단에 큰 빈 영역 노출 / 기대 결과: 컨텐츠 높이만큼의 바텀시트로 표시

## 수정 방향
`ReportPollViewController` 자체에서 `modalPresentationStyle = .overCurrentContext`를 설정하고, `CreatePollModalViewController`와 동일하게 `DimManager`로 배경 딤을 표시/해제하도록 수정했습니다. 호출부 수정 없이 VC 초기화 시점에 스타일이 보장됩니다.

**수정 내용:**
- `ReportPollViewController.swift`: init에서 `modalPresentationStyle = .overCurrentContext` 설정, viewDidLoad에서 딤 표시, dismiss 오버라이드로 딤 해제

## 검증
- ✅ Debug 빌드 성공 (three-dollar-in-my-pocket-debug)
- ✅ SwiftLint 통과 (신규 코드 위반 없음)
- ✅ **시뮬레이터 Before/After 검증 PASS** (iPhone 17 Pro 시뮬레이터 / iOS 26.2, idb 기반 UI 자동화)
  - 시나리오: 커뮤니티 탭 → 투표 상세 진입 → 타인 댓글의 신고 버튼 탭 (신고 전송은 하지 않음)
  - **Before (develop)**: 신고 시트가 화면 전체 높이 pageSheet로 표시되어 상단 절반 이상이 빈 영역 → 티켓 버그 재현 확인
  - **After (본 브랜치)**: 신고 시트가 컨텐츠 높이(신고 사유 목록 + 신고하기 버튼)만큼만 하단에 표시되고, 뒤로 투표 상세 화면이 딤 처리되어 정상 노출
  - 닫기(X) 버튼·배경 딤 표시 정상 동작 확인

### 시뮬레이터 검증 스크린샷
| Before (develop) — 전체 높이, 상단 빈 영역 | After (본 브랜치) — 컨텐츠 높이 |
|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-1191-before.png" width="320"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-1191-after.png" width="320"> |

## 영향 범위
- 투표 댓글 신고 바텀시트 (호출처는 PollDetailViewController 1곳)
- **리스크:** 매우 낮음 (같은 모듈에서 검증된 CreatePollModalViewController 패턴을 그대로 적용)

## 관련 이슈
- Jira: TH-1191

🤖 Generated with [Claude Code](https://claude.com/claude-code)