### PR TITLE
TH-1251 홈 지도 초기 줌 레벨 적용

### DIFF
--- a/Modules/Core/Model/Sources/Domain/Response/HomeFilterScreenResponse.swift
+++ b/Modules/Core/Model/Sources/Domain/Response/HomeFilterScreenResponse.swift
@@ -2,9 +2,15 @@ import Foundation
 
 public struct HomeFilterScreenResponse: Decodable {
     public let sections: [any HomeScreenSection]
+    public let configuration: Configuration?
+
+    public struct Configuration: Decodable {
+        public let initialMapZoomLevel: Double
+    }
 
     public enum CodingKeys: String, CodingKey {
         case sections
+        case configuration
     }
 
     public init(from decoder: any Decoder) throws {
@@ -26,6 +32,7 @@ public struct HomeFilterScreenResponse: Decodable {
             }
         }
         self.sections = sections
+        self.configuration = try container.decodeIfPresent(Configuration.self, forKey: .configuration)
     }
 }
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeView.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeView.swift
@@ -149,15 +149,21 @@ final class HomeView: BaseView {
         }
     }
     
-    func moveCamera(location: CLLocation) {
+    func moveCamera(location: CLLocation, zoomLevel: Double? = nil) {
+        let currentCameraPosition = mapView.cameraPosition
         let target = NMGLatLng(lat: location.coordinate.latitude, lng: location.coordinate.longitude)
-        let cameraPosition = NMFCameraPosition(target, zoom: mapView.zoomLevel)
+        let cameraPosition = NMFCameraPosition(
+            target,
+            zoom: zoomLevel ?? currentCameraPosition.zoom,
+            tilt: currentCameraPosition.tilt,
+            heading: currentCameraPosition.heading
+        )
         let cameraUpdate = NMFCameraUpdate(position: cameraPosition)
         
         cameraUpdate.animation = .easeIn
         mapView.moveCamera(cameraUpdate)
     }
-    
+
     func setAdvertisementMarker(_ advertisement: AdvertisementResponse) {
         guard let urlString = advertisement.image?.url,
               let url = URL(string: urlString) else { return }

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewController.swift
@@ -174,8 +174,11 @@ public final class HomeViewController: BaseViewController {
         viewModel.output.cameraPosition
             .receive(on: DispatchQueue.main)
             .withUnretained(self)
-            .sink { owner, location in
-                owner.homeView.moveCamera(location: location)
+            .sink { owner, cameraPosition in
+                owner.homeView.moveCamera(
+                    location: cameraPosition.0,
+                    zoomLevel: cameraPosition.1
+                )
             }
             .store(in: &cancellables)
 

--- a/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
+++ b/Modules/Feature/Home/Targets/Home/Sources/Domains/Home/HomeViewModel.swift
@@ -50,7 +50,7 @@ extension HomeViewModel {
         let address = PassthroughSubject<String, Never>()
         let filterDatasource = CurrentValueSubject<[HomeFilterCollectionView.CellType], Never>([])
         let isHiddenResearchButton = PassthroughSubject<Bool, Never>()
-        let cameraPosition = PassthroughSubject<CLLocation, Never>()
+        let cameraPosition = PassthroughSubject<(CLLocation, Double?), Never>()
         let advertisementMarker = PassthroughSubject<AdvertisementResponse, Never>()
         /// 바텀시트로 전달할 카드 목록.
         let bottomSheetCards = CurrentValueSubject<[any HomeListCardComponent], Never>([])
@@ -74,6 +74,7 @@ extension HomeViewModel {
         var filterSections: [any HomeScreenSection] = []
         var radioSelection: [String: Int] = [:]
         var hasLoadedFilterScreen = false
+        var initialMapZoomLevel: Double?
         var mapMaxDistance: Double?
         var newCameraPosition: CLLocation?
         var newMapMaxDistance: Double?
@@ -190,22 +191,16 @@ final class HomeViewModel: BaseViewModel {
             })
             .store(in: &cancellables)
 
-        getCurrentLocation
-            .withUnretained(self)
-            .sink(receiveValue: { (owner: HomeViewModel, location: CLLocation) in
-                owner.state.resultCameraPosition = location
-                owner.state.currentLocation = owner.state.resultCameraPosition
-                owner.state.newCameraPosition = location
-                owner.output.cameraPosition.send(location)
-                owner.dependency.preference.userCurrentLocation = location
-            })
-            .store(in: &cancellables)
-
-        // 첫 카드 요청은 위치 + 필터 응답이 모두 준비된 뒤에만 발사한다.
+        // 최초 카메라는 위치와 필터 설정 응답이 모두 준비된 뒤 한 번만 이동한다.
         Publishers.CombineLatest(getCurrentLocation, filterScreenLoaded)
             .first()
             .withUnretained(self)
-            .sink(receiveValue: { (owner: HomeViewModel, _) in
+            .sink(receiveValue: { (owner: HomeViewModel, values) in
+                let location = values.0
+                owner.state.resultCameraPosition = location
+                owner.state.currentLocation = location
+                owner.state.newCameraPosition = location
+                owner.output.cameraPosition.send((location, owner.state.initialMapZoomLevel))
                 owner.fetchInitialCards()
             })
             .store(in: &cancellables)
@@ -330,7 +325,7 @@ final class HomeViewModel: BaseViewModel {
                 let location = CLLocation(latitude: latitude, longitude: longitude)
                 owner.state.newCameraPosition = location
                 owner.state.resultCameraPosition = location
-                owner.output.cameraPosition.send(location)
+                owner.output.cameraPosition.send((location, nil))
                 owner.fetchInitialCards()
                 owner.output.isHiddenResearchButton.send(true)
             })
@@ -386,7 +381,7 @@ final class HomeViewModel: BaseViewModel {
                 owner.sendClickCurrentLocationLog()
                 owner.dependency.preference.userCurrentLocation = location
                 owner.state.currentLocation = location
-                owner.output.cameraPosition.send(location)
+                owner.output.cameraPosition.send((location, nil))
             }
             .store(in: &cancellables)
 
@@ -564,7 +559,7 @@ final class HomeViewModel: BaseViewModel {
                     latitude: marker.location.latitude,
                     longitude: marker.location.longitude
                 )
-                output.cameraPosition.send(cameraPosition)
+                output.cameraPosition.send((cameraPosition, nil))
             }
         } else if let admob = card as? HomeListAdmobCardResponse {
             dependency.logManager.sendEvent(event: ClickEvent(clickLog: admob.clickLog))
@@ -709,6 +704,7 @@ extension HomeViewModel {
             case .success(let response):
                 state.filterSections = response.sections
                 state.hasLoadedFilterScreen = true
+                state.initialMapZoomLevel = response.configuration?.initialMapZoomLevel
                 initializeRadioSelectionDefaults()
                 syncRadioSelectionFromLegacy()
                 output.filterDatasource.send(flattenFilterDatasource())

--- a/Modules/Feature/Store/Derived/Sources/TuistStrings+Store.swift
+++ b/Modules/Feature/Store/Derived/Sources/TuistStrings+Store.swift
@@ -450,5 +450,5 @@ extension StoreStrings {
 }
 
 // swiftlint:disable convenience_type
-// swiftformat:enable all
 // swiftlint:enable all
+// swiftformat:enable all


### PR DESCRIPTION
## 변경 사항

- 홈 화면 응답의 `configuration.initialMapZoomLevel`을 디코딩합니다.
- 응답값을 홈 지도에 전달해 Naver Map SDK의 `NMFCameraUpdate(zoomTo:)`와 `.easeIn` 애니메이션으로 적용합니다.
- 서버 설정값이 없는 이전 응답은 기존 기본 줌 레벨(15)을 유지합니다.

## 검증

- `xcodebuild -workspace 3dollar-in-my-pocket.xcworkspace -scheme three-dollar-in-my-pocket-debug -configuration Debug -destination 'platform=iOS Simulator,id=10E938D5-726A-4E6A-8902-8BEE0EA3E562' build CODE_SIGNING_ALLOWED=NO` 성공
- 개발 서버 `GET /api/v1/screen/home` 응답: `initialMapZoomLevel: 15.0`
- iPhone 17 Pro (iOS 26.2) 시뮬레이터에서 15.0과 제어값 13.0의 줌 범위가 다르게 적용되는 것을 확인

## 스크린샷

| 개발 서버 응답: 15.0 | 제어 응답값: 13.0 |
|:---:|:---:|
| ![개발 서버 응답 15.0](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-1251-server-zoom-15.png) | ![제어 응답값 13.0](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/download/verification-assets/TH-1251-controlled-zoom-13.png) |

13.0은 서버 관리값을 변경하지 않기 위해 동일한 응답 전달 경로에 일시 주입해 검증했으며, 최종 코드에는 포함하지 않았습니다. 검증 이미지는 [verification-assets prerelease](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/releases/tag/verification-assets)에 보관합니다.